### PR TITLE
feat(data): add minimal preprocessing and dataset loading pipeline

### DIFF
--- a/scripts/check_dataset_loading.py
+++ b/scripts/check_dataset_loading.py
@@ -1,0 +1,172 @@
+﻿"""Smoke-test dataset loading and optionally save preprocessing previews."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.data import (  # noqa: E402
+    DEFAULT_ARCHIVE_PATH,
+    DEFAULT_PAIRED_INDEX_PATH,
+    DEFAULT_SINGLE_INDEX_PATH,
+    PairedBreastDataset,
+    SingleImageDataset,
+    build_eval_transform,
+    build_train_transform,
+)
+
+
+DEFAULT_PREVIEW_DIR = REPO_ROOT / "outputs" / "dataset_loading_preview"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", choices=("single", "paired"), default="single")
+    parser.add_argument("--mode", choices=("train", "eval"), default="eval")
+    parser.add_argument("--single-index", type=Path, default=REPO_ROOT / DEFAULT_SINGLE_INDEX_PATH)
+    parser.add_argument("--paired-index", type=Path, default=REPO_ROOT / DEFAULT_PAIRED_INDEX_PATH)
+    parser.add_argument("--archive-path", type=Path, default=REPO_ROOT / DEFAULT_ARCHIVE_PATH)
+    parser.add_argument("--image-root", type=Path, default=None)
+    parser.add_argument("--image-size", type=int, default=1024)
+    parser.add_argument("--num-channels", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--num-batches", type=int, default=1)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--save-preview", action="store_true")
+    parser.add_argument("--preview-dir", type=Path, default=DEFAULT_PREVIEW_DIR)
+    return parser.parse_args()
+
+
+def build_dataset(args: argparse.Namespace):
+    if args.mode == "train":
+        transform = build_train_transform(
+            image_size=args.image_size,
+            num_channels=args.num_channels,
+            enable_augmentation=False,
+        )
+    else:
+        transform = build_eval_transform(
+            image_size=args.image_size,
+            num_channels=args.num_channels,
+        )
+
+    if args.dataset == "single":
+        dataset = SingleImageDataset(
+            index_csv_path=args.single_index,
+            archive_path=args.archive_path,
+            transform=transform,
+            image_root=args.image_root,
+        )
+    else:
+        dataset = PairedBreastDataset(
+            index_csv_path=args.paired_index,
+            archive_path=args.archive_path,
+            transform=transform,
+            image_root=args.image_root,
+        )
+    return dataset
+
+
+def tensor_summary(name: str, tensor: torch.Tensor) -> str:
+    return (
+        f"{name}: shape={tuple(tensor.shape)} dtype={tensor.dtype} "
+        f"min={tensor.min().item():.4f} max={tensor.max().item():.4f}"
+    )
+
+
+def save_preview(batch: dict[str, object], dataset_type: str, output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved_paths: list[Path] = []
+
+    if dataset_type == "single":
+        images = batch["image"]
+        image_ids = batch["image_id"]
+        for index in range(min(4, len(image_ids))):
+            path = output_dir / f"single_{index}_{image_ids[index]}.png"
+            image = tensor_to_image(images[index])
+            image.save(path)
+            saved_paths.append(path)
+    else:
+        x_cc = batch["x_cc"]
+        x_mlo = batch["x_mlo"]
+        breast_ids = batch["breast_id"]
+        for index in range(min(4, len(breast_ids))):
+            cc_image = tensor_to_image(x_cc[index])
+            mlo_image = tensor_to_image(x_mlo[index])
+            merged = Image.new("L", (cc_image.width + mlo_image.width, cc_image.height))
+            merged.paste(cc_image, (0, 0))
+            merged.paste(mlo_image, (cc_image.width, 0))
+            path = output_dir / f"paired_{index}_{breast_ids[index]}.png"
+            merged.save(path)
+            saved_paths.append(path)
+
+    return saved_paths
+
+
+def tensor_to_image(tensor: torch.Tensor) -> Image.Image:
+    array = tensor[0].detach().cpu().clamp(0, 1).mul(255).to(torch.uint8).numpy()
+    return Image.fromarray(np.asarray(array))
+
+
+def print_batch_summary(batch: dict[str, object], dataset_type: str) -> None:
+    print(f"- keys: {list(batch.keys())}")
+    if dataset_type == "single":
+        print(f"- {tensor_summary('image', batch['image'])}")
+        print(f"- {tensor_summary('target', batch['target'])}")
+        print(f"- image_id sample: {batch['image_id'][:2]}")
+        print(f"- breast_id sample: {batch['breast_id'][:2]}")
+        print(f"- image_path sample: {batch['image_path'][:2]}")
+    else:
+        print(f"- {tensor_summary('x_cc', batch['x_cc'])}")
+        print(f"- {tensor_summary('x_mlo', batch['x_mlo'])}")
+        print(f"- {tensor_summary('target', batch['target'])}")
+        print(f"- breast_id sample: {batch['breast_id'][:2]}")
+        print(f"- image_path_cc sample: {batch['image_path_cc'][:2]}")
+        print(f"- image_path_mlo sample: {batch['image_path_mlo'][:2]}")
+
+
+def main() -> int:
+    args = parse_args()
+    dataset = build_dataset(args)
+    print(f"Dataset: {args.dataset}")
+    print(f"Mode: {args.mode}")
+    print(f"Length: {len(dataset)}")
+
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+    )
+
+    saved_paths: list[Path] = []
+    try:
+        for batch_index, batch in enumerate(loader):
+            if batch_index >= args.num_batches:
+                break
+            print(f"Batch {batch_index}")
+            print_batch_summary(batch, args.dataset)
+            if args.save_preview and not saved_paths:
+                saved_paths = save_preview(batch, args.dataset, args.preview_dir)
+    finally:
+        dataset.close()
+
+    if saved_paths:
+        print(f"- saved preview files: {[str(path) for path in saved_paths]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -1,0 +1,147 @@
+﻿"""Minimal dataset loaders for Stage 1 Issue 1.2."""
+
+from __future__ import annotations
+
+import csv
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Callable
+from zipfile import ZipFile
+
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+DEFAULT_SINGLE_INDEX_PATH = Path("data/processed/metadata/primary_single_image_index.csv")
+DEFAULT_PAIRED_INDEX_PATH = Path("data/processed/metadata/primary_paired_breast_index.csv")
+DEFAULT_ARCHIVE_PATH = Path("data/raw/primary/train_img.zip")
+
+
+class ArchiveImageReader:
+    """Read course images from an extracted root or directly from the zip archive."""
+
+    def __init__(self, archive_path: str | Path, image_root: str | Path | None = None) -> None:
+        self.archive_path = Path(archive_path)
+        self.image_root = Path(image_root) if image_root else None
+        self._archive: ZipFile | None = None
+
+    def read(self, image_path: str) -> Image.Image:
+        filesystem_path = self._resolve_filesystem_path(image_path)
+        if filesystem_path is not None and filesystem_path.exists():
+            with Image.open(filesystem_path) as image:
+                return image.convert("RGB")
+
+        archive = self._get_archive()
+        with archive.open(image_path) as handle:
+            data = handle.read()
+        with Image.open(BytesIO(data)) as image:
+            return image.convert("RGB")
+
+    def close(self) -> None:
+        if self._archive is not None:
+            self._archive.close()
+            self._archive = None
+
+    def _resolve_filesystem_path(self, image_path: str) -> Path | None:
+        if self.image_root is None:
+            return None
+        return self.image_root / image_path
+
+    def _get_archive(self) -> ZipFile:
+        if self._archive is None:
+            self._archive = ZipFile(self.archive_path)
+        return self._archive
+
+    def __del__(self) -> None:
+        self.close()
+
+
+class SingleImageDataset(Dataset[dict[str, Any]]):
+    """Load single-image mammography samples from the normalized index."""
+
+    def __init__(
+        self,
+        index_csv_path: str | Path,
+        archive_path: str | Path,
+        transform: Callable[[Image.Image, str], torch.Tensor],
+        image_root: str | Path | None = None,
+    ) -> None:
+        self.index_csv_path = Path(index_csv_path)
+        self.transform = transform
+        self.rows = _load_index_rows(self.index_csv_path)
+        self.image_reader = ArchiveImageReader(archive_path=archive_path, image_root=image_root)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        row = self.rows[index]
+        image = self.image_reader.read(row["image_path"])
+        tensor = self.transform(image, laterality=row.get("laterality", ""))
+        target = torch.tensor(float(row["is_malignant"]), dtype=torch.float32)
+        return {
+            "image": tensor,
+            "target": target,
+            "image_id": row["image_id"],
+            "breast_id": row["breast_id"],
+            "view": row["view"],
+            "image_path": row["image_path"],
+            "laterality": row.get("laterality", ""),
+        }
+
+    def close(self) -> None:
+        self.image_reader.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+
+class PairedBreastDataset(Dataset[dict[str, Any]]):
+    """Load paired CC/MLO breast-level samples from the normalized index."""
+
+    def __init__(
+        self,
+        index_csv_path: str | Path,
+        archive_path: str | Path,
+        transform: Callable[[Image.Image, str], torch.Tensor],
+        image_root: str | Path | None = None,
+    ) -> None:
+        self.index_csv_path = Path(index_csv_path)
+        self.transform = transform
+        self.rows = _load_index_rows(self.index_csv_path)
+        self.image_reader = ArchiveImageReader(archive_path=archive_path, image_root=image_root)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        row = self.rows[index]
+        laterality = row.get("laterality", "")
+        cc_image = self.image_reader.read(row["image_path_cc"])
+        mlo_image = self.image_reader.read(row["image_path_mlo"])
+        x_cc = self.transform(cc_image, laterality=laterality)
+        x_mlo = self.transform(mlo_image, laterality=laterality)
+        target = torch.tensor(float(row["is_malignant"]), dtype=torch.float32)
+        return {
+            "x_cc": x_cc,
+            "x_mlo": x_mlo,
+            "target": target,
+            "breast_id": row["breast_id"],
+            "image_path_cc": row["image_path_cc"],
+            "image_path_mlo": row["image_path_mlo"],
+            "image_id_cc": row["image_id_cc"],
+            "image_id_mlo": row["image_id_mlo"],
+            "laterality": laterality,
+        }
+
+    def close(self) -> None:
+        self.image_reader.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+
+def _load_index_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return list(csv.DictReader(handle))

--- a/src/data/transforms.py
+++ b/src/data/transforms.py
@@ -1,0 +1,114 @@
+﻿"""Minimal mammography preprocessing transforms for Stage 1 Issue 1.2."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from PIL import Image, ImageEnhance, ImageOps
+
+
+@dataclass(slots=True)
+class MammographyTransform:
+    """Apply the minimal preprocessing pipeline for mammography images."""
+
+    image_size: int = 1024
+    num_channels: int = 3
+    foreground_threshold: int = 5
+    enable_augmentation: bool = False
+    brightness_jitter: float = 0.05
+    contrast_jitter: float = 0.05
+
+    def __post_init__(self) -> None:
+        if self.image_size <= 0:
+            raise ValueError("image_size must be positive.")
+        if self.num_channels not in (1, 3):
+            raise ValueError("num_channels must be 1 or 3.")
+
+    def __call__(self, image: Image.Image, laterality: str = "") -> torch.Tensor:
+        image = image.convert("L")
+        image = self._crop_foreground(image)
+
+        if laterality.upper() == "R":
+            image = ImageOps.mirror(image)
+
+        if self.enable_augmentation:
+            image = self._apply_light_augmentation(image)
+
+        image = self._resize_and_pad(image)
+        return self._to_tensor(image)
+
+    def _crop_foreground(self, image: Image.Image) -> Image.Image:
+        pixels = np.asarray(image)
+        foreground = np.argwhere(pixels > self.foreground_threshold)
+        if foreground.size == 0:
+            return image
+
+        top, left = foreground.min(axis=0)
+        bottom, right = foreground.max(axis=0)
+        return image.crop((int(left), int(top), int(right) + 1, int(bottom) + 1))
+
+    def _apply_light_augmentation(self, image: Image.Image) -> Image.Image:
+        brightness_factor = random.uniform(
+            1.0 - self.brightness_jitter,
+            1.0 + self.brightness_jitter,
+        )
+        contrast_factor = random.uniform(
+            1.0 - self.contrast_jitter,
+            1.0 + self.contrast_jitter,
+        )
+        image = ImageEnhance.Brightness(image).enhance(brightness_factor)
+        image = ImageEnhance.Contrast(image).enhance(contrast_factor)
+        return image
+
+    def _resize_and_pad(self, image: Image.Image) -> Image.Image:
+        width, height = image.size
+        scale = min(self.image_size / width, self.image_size / height)
+        resized_width = max(1, int(round(width * scale)))
+        resized_height = max(1, int(round(height * scale)))
+
+        resized = image.resize(
+            (resized_width, resized_height),
+            resample=Image.Resampling.BILINEAR,
+        )
+        canvas = Image.new("L", (self.image_size, self.image_size), color=0)
+        offset_x = (self.image_size - resized_width) // 2
+        offset_y = (self.image_size - resized_height) // 2
+        canvas.paste(resized, (offset_x, offset_y))
+        return canvas
+
+    def _to_tensor(self, image: Image.Image) -> torch.Tensor:
+        pixels = np.asarray(image, dtype=np.float32) / 255.0
+        tensor = torch.from_numpy(pixels).unsqueeze(0)
+        if self.num_channels == 3:
+            tensor = tensor.repeat(3, 1, 1)
+        return tensor.to(dtype=torch.float32)
+
+
+def build_train_transform(
+    image_size: int = 1024,
+    num_channels: int = 3,
+    enable_augmentation: bool = False,
+) -> MammographyTransform:
+    """Build the minimal training transform."""
+
+    return MammographyTransform(
+        image_size=image_size,
+        num_channels=num_channels,
+        enable_augmentation=enable_augmentation,
+    )
+
+
+def build_eval_transform(
+    image_size: int = 1024,
+    num_channels: int = 3,
+) -> MammographyTransform:
+    """Build the deterministic evaluation transform."""
+
+    return MammographyTransform(
+        image_size=image_size,
+        num_channels=num_channels,
+        enable_augmentation=False,
+    )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,259 @@
+﻿from __future__ import annotations
+
+import csv
+import shutil
+import unittest
+import uuid
+from pathlib import Path
+from zipfile import ZipFile
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+from src.data import PAIRED_BREAST_FIELDS, SINGLE_IMAGE_FIELDS
+from src.data.datasets import PairedBreastDataset, SingleImageDataset
+from src.data.transforms import build_eval_transform
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_TMP_ROOT = REPO_ROOT / "outputs" / "test_tmp"
+
+
+class DatasetTransformTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        TEST_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        self.root = TEST_TMP_ROOT / uuid.uuid4().hex
+        self.root.mkdir(parents=True, exist_ok=False)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_transform_outputs_float32_three_channel_tensor(self) -> None:
+        pixels = np.zeros((6, 8), dtype=np.uint8)
+        pixels[1:5, 2:6] = 180
+        image = Image.fromarray(pixels).convert("RGB")
+        transform = build_eval_transform(image_size=8, num_channels=3)
+
+        tensor = transform(image, laterality="L")
+
+        self.assertEqual(tensor.shape, (3, 8, 8))
+        self.assertEqual(tensor.dtype, torch.float32)
+        self.assertTrue(torch.allclose(tensor[0], tensor[1]))
+        self.assertTrue(torch.allclose(tensor[1], tensor[2]))
+
+    def test_right_laterality_is_horizontally_flipped(self) -> None:
+        pixels = np.full((6, 8), 10, dtype=np.uint8)
+        pixels[:, :4] = 220
+        image = Image.fromarray(pixels).convert("RGB")
+        transform = build_eval_transform(image_size=8, num_channels=1)
+
+        left_tensor = transform(image, laterality="L")
+        right_tensor = transform(image, laterality="R")
+
+        self.assertTrue(torch.allclose(right_tensor[0], torch.flip(left_tensor[0], dims=[1])))
+
+    def test_empty_foreground_falls_back_to_original_image(self) -> None:
+        image = Image.fromarray(np.zeros((5, 7), dtype=np.uint8)).convert("RGB")
+        transform = build_eval_transform(image_size=8, num_channels=1)
+
+        tensor = transform(image, laterality="L")
+
+        self.assertEqual(tensor.shape, (1, 8, 8))
+        self.assertEqual(float(tensor.sum().item()), 0.0)
+
+    def test_single_image_dataset_and_dataloader(self) -> None:
+        single_index_path, paired_index_path, archive_path = self.create_dataset_files()
+        dataset = SingleImageDataset(
+            index_csv_path=single_index_path,
+            archive_path=archive_path,
+            transform=build_eval_transform(image_size=16, num_channels=3),
+        )
+
+        sample = dataset[0]
+        self.assertEqual(
+            set(sample.keys()),
+            {"image", "target", "image_id", "breast_id", "view", "image_path", "laterality"},
+        )
+        self.assertEqual(sample["image"].shape, (3, 16, 16))
+        self.assertEqual(sample["target"].dtype, torch.float32)
+
+        loader = DataLoader(dataset, batch_size=2, shuffle=False, num_workers=0)
+        batch = next(iter(loader))
+        self.assertEqual(batch["image"].shape, (2, 3, 16, 16))
+        self.assertEqual(batch["target"].shape, (2,))
+        dataset.close()
+
+    def test_paired_dataset_and_dataloader(self) -> None:
+        single_index_path, paired_index_path, archive_path = self.create_dataset_files()
+        dataset = PairedBreastDataset(
+            index_csv_path=paired_index_path,
+            archive_path=archive_path,
+            transform=build_eval_transform(image_size=16, num_channels=3),
+        )
+
+        sample = dataset[0]
+        self.assertEqual(
+            set(sample.keys()),
+            {
+                "x_cc",
+                "x_mlo",
+                "target",
+                "breast_id",
+                "image_path_cc",
+                "image_path_mlo",
+                "image_id_cc",
+                "image_id_mlo",
+                "laterality",
+            },
+        )
+        self.assertEqual(sample["x_cc"].shape, (3, 16, 16))
+        self.assertEqual(sample["x_mlo"].shape, (3, 16, 16))
+
+        loader = DataLoader(dataset, batch_size=1, shuffle=False, num_workers=0)
+        batch = next(iter(loader))
+        self.assertEqual(batch["x_cc"].shape, (1, 3, 16, 16))
+        self.assertEqual(batch["x_mlo"].shape, (1, 3, 16, 16))
+        self.assertEqual(batch["target"].shape, (1,))
+        dataset.close()
+
+    def create_dataset_files(self) -> tuple[Path, Path, Path]:
+        archive_path = self.root / "train_img.zip"
+        single_index_path = self.root / "single.csv"
+        paired_index_path = self.root / "paired.csv"
+
+        self.write_archive(archive_path)
+        self.write_single_index(single_index_path)
+        self.write_paired_index(paired_index_path)
+        return single_index_path, paired_index_path, archive_path
+
+    def write_archive(self, archive_path: Path) -> None:
+        left_cc = self.make_rgb_image(8, 10, bright_left=True)
+        left_mlo = self.make_rgb_image(8, 10, bright_left=False)
+        right_cc = self.make_rgb_image(8, 10, bright_left=True)
+        right_mlo = self.make_rgb_image(8, 10, bright_left=False)
+
+        with ZipFile(archive_path, "w") as archive:
+            archive.writestr("train_img/A_L/A_L_CC.jpg", self.encode_image(left_cc))
+            archive.writestr("train_img/A_L/A_L_MLO.jpg", self.encode_image(left_mlo))
+            archive.writestr("train_img/B_R/B_R_CC.jpg", self.encode_image(right_cc))
+            archive.writestr("train_img/B_R/B_R_MLO.jpg", self.encode_image(right_mlo))
+
+    def write_single_index(self, path: Path) -> None:
+        rows = [
+            {
+                "image_id": "A_L_CC",
+                "breast_id": "A_L",
+                "view": "CC",
+                "pathology": "N",
+                "is_malignant": "0",
+                "image_path": "train_img/A_L/A_L_CC.jpg",
+                "laterality": "L",
+                "device": "HLG",
+                "lesion_type": "",
+                "birads": "1",
+                "difficult": "N",
+                "annotations": "[]",
+            },
+            {
+                "image_id": "A_L_MLO",
+                "breast_id": "A_L",
+                "view": "MLO",
+                "pathology": "N",
+                "is_malignant": "0",
+                "image_path": "train_img/A_L/A_L_MLO.jpg",
+                "laterality": "L",
+                "device": "HLG",
+                "lesion_type": "",
+                "birads": "1",
+                "difficult": "N",
+                "annotations": "[]",
+            },
+            {
+                "image_id": "B_R_CC",
+                "breast_id": "B_R",
+                "view": "CC",
+                "pathology": "M",
+                "is_malignant": "1",
+                "image_path": "train_img/B_R/B_R_CC.jpg",
+                "laterality": "R",
+                "device": "HLG",
+                "lesion_type": "",
+                "birads": "4C",
+                "difficult": "N",
+                "annotations": "[]",
+            },
+            {
+                "image_id": "B_R_MLO",
+                "breast_id": "B_R",
+                "view": "MLO",
+                "pathology": "M",
+                "is_malignant": "1",
+                "image_path": "train_img/B_R/B_R_MLO.jpg",
+                "laterality": "R",
+                "device": "HLG",
+                "lesion_type": "",
+                "birads": "4C",
+                "difficult": "N",
+                "annotations": "[]",
+            },
+        ]
+        self.write_csv(path, SINGLE_IMAGE_FIELDS, rows)
+
+    def write_paired_index(self, path: Path) -> None:
+        rows = [
+            {
+                "breast_id": "A_L",
+                "pathology": "N",
+                "is_malignant": "0",
+                "image_id_cc": "A_L_CC",
+                "image_id_mlo": "A_L_MLO",
+                "image_path_cc": "train_img/A_L/A_L_CC.jpg",
+                "image_path_mlo": "train_img/A_L/A_L_MLO.jpg",
+                "laterality": "L",
+                "device": "HLG",
+                "birads": "1",
+            },
+            {
+                "breast_id": "B_R",
+                "pathology": "M",
+                "is_malignant": "1",
+                "image_id_cc": "B_R_CC",
+                "image_id_mlo": "B_R_MLO",
+                "image_path_cc": "train_img/B_R/B_R_CC.jpg",
+                "image_path_mlo": "train_img/B_R/B_R_MLO.jpg",
+                "laterality": "R",
+                "device": "HLG",
+                "birads": "4C",
+            },
+        ]
+        self.write_csv(path, PAIRED_BREAST_FIELDS, rows)
+
+    def write_csv(self, path: Path, fieldnames: tuple[str, ...], rows: list[dict[str, str]]) -> None:
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def make_rgb_image(self, width: int, height: int, bright_left: bool) -> np.ndarray:
+        pixels = np.zeros((height, width), dtype=np.uint8)
+        pixels[1:-1, 1:-1] = 20
+        if bright_left:
+            pixels[2:-2, 1: width // 2] = 220
+        else:
+            pixels[2:-2, width // 2 : -1] = 200
+        return np.repeat(pixels[:, :, None], 3, axis=2)
+
+    def encode_image(self, rgb_pixels: np.ndarray) -> bytes:
+        image = Image.fromarray(rgb_pixels)
+        from io import BytesIO
+
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG")
+        return buffer.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
what:
- implement Stage 1 Issue 1.2 minimal mammography preprocessing and data loading
- add zip-backed image reading and deterministic grayscale preprocessing
- add single-image and paired breast datasets, a loading smoke-check script, and unit tests

why:
- enable the minimal runnable M1 input path for mammography data
- keep the data loading layer stable before expanding to split, training, or evaluation logic