### PR TITLE
feat(train | stage1-4): add minimal single-image baseline training loop

### DIFF
--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -1,0 +1,132 @@
+"""Train the minimal single-image Stage 1 baseline on reusable split artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+from torch import nn
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.data.datasets import DEFAULT_ARCHIVE_PATH  # noqa: E402
+from src.models.baseline import MinimalSingleImageCNN  # noqa: E402
+from src.train.trainer import (  # noqa: E402
+    build_single_image_loaders,
+    compute_pos_weight,
+    fit,
+    set_random_seed,
+)
+
+
+DEFAULT_TRAIN_SPLIT = REPO_ROOT / "data" / "processed" / "splits" / "primary_single_image_split_train.csv"
+DEFAULT_VAL_SPLIT = REPO_ROOT / "data" / "processed" / "splits" / "primary_single_image_split_val.csv"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "m1_baseline"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--train-split", type=Path, default=DEFAULT_TRAIN_SPLIT)
+    parser.add_argument("--val-split", type=Path, default=DEFAULT_VAL_SPLIT)
+    parser.add_argument("--archive-path", type=Path, default=REPO_ROOT / DEFAULT_ARCHIVE_PATH)
+    parser.add_argument("--image-root", type=Path, default=None)
+    parser.add_argument("--image-size", type=int, default=1024)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    set_random_seed(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    config = {
+        "train_split": str(args.train_split),
+        "val_split": str(args.val_split),
+        "archive_path": str(args.archive_path),
+        "image_root": None if args.image_root is None else str(args.image_root),
+        "image_size": args.image_size,
+        "batch_size": args.batch_size,
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "seed": args.seed,
+        "num_workers": args.num_workers,
+        "device": str(device),
+        "model": "MinimalSingleImageCNN",
+    }
+    write_json(output_dir / "config.json", config)
+
+    loader_bundle = build_single_image_loaders(
+        train_split_csv_path=args.train_split,
+        val_split_csv_path=args.val_split,
+        archive_path=args.archive_path,
+        image_root=args.image_root,
+        image_size=args.image_size,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+
+    try:
+        pos_weight = compute_pos_weight(loader_bundle.train_dataset.rows)
+        model = MinimalSingleImageCNN(in_channels=3).to(device)
+        criterion = nn.BCEWithLogitsLoss(
+            pos_weight=torch.tensor(pos_weight, dtype=torch.float32, device=device)
+        )
+        optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+        fit_result = fit(
+            model=model,
+            train_loader=loader_bundle.train_loader,
+            val_loader=loader_bundle.val_loader,
+            optimizer=optimizer,
+            criterion=criterion,
+            device=device,
+            epochs=args.epochs,
+            output_dir=output_dir,
+        )
+    finally:
+        loader_bundle.close()
+
+    metrics_summary = {
+        "config": config,
+        "train_samples": len(loader_bundle.train_dataset),
+        "val_samples": len(loader_bundle.val_dataset),
+        "pos_weight": pos_weight,
+        "best_epoch": fit_result["best_epoch"],
+        "best_metrics": fit_result["best_metrics"],
+        "history": fit_result["history"],
+        "best_checkpoint_path": str(fit_result["best_checkpoint_path"]),
+    }
+    write_json(output_dir / "metrics_summary.json", metrics_summary)
+
+    print("Training finished successfully")
+    print(f"- best epoch: {fit_result['best_epoch']}")
+    print(f"- best val loss: {fit_result['best_metrics']['val_loss']:.4f}")
+    print(f"- wrote: {output_dir / 'config.json'}")
+    print(f"- wrote: {output_dir / 'metrics_summary.json'}")
+    print(f"- wrote: {fit_result['best_checkpoint_path']}")
+    return 0
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model definitions for the breast cancer detection project."""
+
+from .baseline import MinimalSingleImageCNN
+
+__all__ = ["MinimalSingleImageCNN"]

--- a/src/models/baseline.py
+++ b/src/models/baseline.py
@@ -1,0 +1,42 @@
+"""Minimal baseline model for Stage 1 training."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class ConvBlock(nn.Module):
+    """Small downsampling block used by the baseline CNN."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=2, padding=1, bias=False),
+            nn.GroupNorm(4, out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class MinimalSingleImageCNN(nn.Module):
+    """A compact CNN baseline for image-level malignant classification."""
+
+    def __init__(self, in_channels: int = 3) -> None:
+        super().__init__()
+        channels = (16, 32, 64, 128)
+        self.features = nn.Sequential(
+            ConvBlock(in_channels, channels[0]),
+            ConvBlock(channels[0], channels[1]),
+            ConvBlock(channels[1], channels[2]),
+            ConvBlock(channels[2], channels[3]),
+            nn.AdaptiveAvgPool2d(1),
+        )
+        self.classifier = nn.Linear(channels[-1], 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = torch.flatten(x, start_dim=1)
+        return self.classifier(x).squeeze(1)

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -1,0 +1,21 @@
+"""Training utilities for the breast cancer detection project."""
+
+from .trainer import (
+    SingleImageLoaderBundle,
+    build_single_image_loaders,
+    compute_pos_weight,
+    fit,
+    set_random_seed,
+    train_one_epoch,
+    validate_one_epoch,
+)
+
+__all__ = [
+    "SingleImageLoaderBundle",
+    "set_random_seed",
+    "build_single_image_loaders",
+    "compute_pos_weight",
+    "train_one_epoch",
+    "validate_one_epoch",
+    "fit",
+]

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -1,0 +1,277 @@
+"""Minimal training utilities for the Stage 1 single-image baseline."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+from torch import nn
+from torch.utils.data import DataLoader
+
+from src.data.datasets import DEFAULT_ARCHIVE_PATH, SingleImageDataset
+from src.data.transforms import build_eval_transform, build_train_transform
+
+
+@dataclass
+class SingleImageLoaderBundle:
+    """Own the datasets and dataloaders needed by the minimal train loop."""
+
+    train_dataset: SingleImageDataset
+    val_dataset: SingleImageDataset
+    train_loader: DataLoader[dict[str, Any]]
+    val_loader: DataLoader[dict[str, Any]]
+
+    def close(self) -> None:
+        self.train_dataset.close()
+        self.val_dataset.close()
+
+
+def set_random_seed(seed: int) -> None:
+    """Set random seeds for the current process."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def build_single_image_loaders(
+    train_split_csv_path: str | Path,
+    val_split_csv_path: str | Path,
+    archive_path: str | Path = DEFAULT_ARCHIVE_PATH,
+    image_root: str | Path | None = None,
+    image_size: int = 1024,
+    batch_size: int = 8,
+    num_workers: int = 0,
+) -> SingleImageLoaderBundle:
+    """Build train/val dataloaders from the reusable single-image split artifacts."""
+
+    train_dataset = SingleImageDataset(
+        index_csv_path=train_split_csv_path,
+        archive_path=archive_path,
+        transform=build_train_transform(image_size=image_size, num_channels=3, enable_augmentation=False),
+        image_root=image_root,
+    )
+    val_dataset = SingleImageDataset(
+        index_csv_path=val_split_csv_path,
+        archive_path=archive_path,
+        transform=build_eval_transform(image_size=image_size, num_channels=3),
+        image_root=image_root,
+    )
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+    )
+    return SingleImageLoaderBundle(
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        train_loader=train_loader,
+        val_loader=val_loader,
+    )
+
+
+def compute_pos_weight(train_rows: list[dict[str, str]]) -> float:
+    """Compute the positive-class weight from the training split."""
+
+    labels = [int(row["is_malignant"]) for row in train_rows]
+    positive_count = sum(labels)
+    negative_count = len(labels) - positive_count
+    if positive_count == 0:
+        raise ValueError("Training split contains no positive samples; cannot compute pos_weight.")
+    if negative_count == 0:
+        raise ValueError("Training split contains no negative samples; cannot compute pos_weight.")
+    return float(negative_count / positive_count)
+
+
+def train_one_epoch(
+    model: nn.Module,
+    loader: DataLoader[dict[str, Any]],
+    optimizer: torch.optim.Optimizer,
+    criterion: nn.Module,
+    device: torch.device,
+) -> dict[str, float]:
+    """Run one training epoch and return the average train loss."""
+
+    model.train()
+    total_loss = 0.0
+    total_samples = 0
+
+    for batch in loader:
+        images = batch["image"].to(device)
+        targets = batch["target"].to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(images)
+        loss = criterion(logits, targets)
+        loss.backward()
+        optimizer.step()
+
+        batch_size = images.size(0)
+        total_loss += loss.item() * batch_size
+        total_samples += batch_size
+
+    return {"train_loss": total_loss / max(total_samples, 1)}
+
+
+def validate_one_epoch(
+    model: nn.Module,
+    loader: DataLoader[dict[str, Any]],
+    criterion: nn.Module,
+    device: torch.device,
+) -> dict[str, Any]:
+    """Run one validation epoch and return image-level and breast-level metrics."""
+
+    model.eval()
+    total_loss = 0.0
+    total_samples = 0
+    probabilities: list[float] = []
+    targets: list[int] = []
+    breast_ids: list[str] = []
+
+    with torch.no_grad():
+        for batch in loader:
+            images = batch["image"].to(device)
+            batch_targets = batch["target"].to(device)
+            logits = model(images)
+            loss = criterion(logits, batch_targets)
+
+            batch_size = images.size(0)
+            total_loss += loss.item() * batch_size
+            total_samples += batch_size
+
+            batch_probabilities = torch.sigmoid(logits).cpu().tolist()
+            probabilities.extend(float(probability) for probability in batch_probabilities)
+            targets.extend(int(value) for value in batch_targets.cpu().tolist())
+            breast_ids.extend(str(breast_id) for breast_id in batch["breast_id"])
+
+    breast_targets, breast_probabilities = _aggregate_breast_mean_predictions(
+        probabilities=probabilities,
+        targets=targets,
+        breast_ids=breast_ids,
+    )
+
+    return {
+        "val_loss": total_loss / max(total_samples, 1),
+        "image_accuracy": _binary_accuracy(targets, probabilities),
+        "image_auroc": _safe_auroc(targets, probabilities),
+        "breast_mean_accuracy": _binary_accuracy(breast_targets, breast_probabilities),
+        "breast_mean_auroc": _safe_auroc(breast_targets, breast_probabilities),
+        "num_val_images": total_samples,
+        "num_val_breasts": len(breast_targets),
+    }
+
+
+def fit(
+    model: nn.Module,
+    train_loader: DataLoader[dict[str, Any]],
+    val_loader: DataLoader[dict[str, Any]],
+    optimizer: torch.optim.Optimizer,
+    criterion: nn.Module,
+    device: torch.device,
+    epochs: int,
+    output_dir: str | Path,
+) -> dict[str, Any]:
+    """Run the minimal train/val loop and save the best checkpoint by val loss."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = output_path / "best_model.pt"
+
+    history: list[dict[str, Any]] = []
+    best_epoch = -1
+    best_val_loss = float("inf")
+
+    for epoch in range(1, epochs + 1):
+        train_metrics = train_one_epoch(model, train_loader, optimizer, criterion, device)
+        val_metrics = validate_one_epoch(model, val_loader, criterion, device)
+        epoch_metrics = {
+            "epoch": epoch,
+            **train_metrics,
+            **val_metrics,
+        }
+        history.append(epoch_metrics)
+        print(
+            "Epoch "
+            f"{epoch}/{epochs} "
+            f"train_loss={epoch_metrics['train_loss']:.4f} "
+            f"val_loss={epoch_metrics['val_loss']:.4f} "
+            f"image_acc={epoch_metrics['image_accuracy']:.4f} "
+            f"image_auroc={_format_metric_value(epoch_metrics['image_auroc'])} "
+            f"breast_mean_acc={epoch_metrics['breast_mean_accuracy']:.4f} "
+            f"breast_mean_auroc={_format_metric_value(epoch_metrics['breast_mean_auroc'])}"
+        )
+
+        if val_metrics["val_loss"] < best_val_loss:
+            best_val_loss = float(val_metrics["val_loss"])
+            best_epoch = epoch
+            torch.save(model.state_dict(), checkpoint_path)
+
+    if best_epoch == -1:
+        raise RuntimeError("Training finished without producing any epoch metrics.")
+
+    best_metrics = next(metric for metric in history if metric["epoch"] == best_epoch)
+    return {
+        "history": history,
+        "best_epoch": best_epoch,
+        "best_metrics": best_metrics,
+        "best_checkpoint_path": checkpoint_path,
+    }
+
+
+def _binary_accuracy(targets: list[int], probabilities: list[float]) -> float:
+    if not targets:
+        return 0.0
+    predictions = [1 if probability >= 0.5 else 0 for probability in probabilities]
+    correct = sum(int(prediction == target) for prediction, target in zip(predictions, targets))
+    return float(correct / len(targets))
+
+
+def _safe_auroc(targets: list[int], probabilities: list[float]) -> float | None:
+    if len(set(targets)) < 2:
+        return None
+    return float(roc_auc_score(targets, probabilities))
+
+
+def _format_metric_value(value: float | None) -> str:
+    if value is None:
+        return "None"
+    return f"{value:.4f}"
+
+
+def _aggregate_breast_mean_predictions(
+    probabilities: list[float],
+    targets: list[int],
+    breast_ids: list[str],
+) -> tuple[list[int], list[float]]:
+    grouped_probabilities: dict[str, list[float]] = defaultdict(list)
+    grouped_targets: dict[str, list[int]] = defaultdict(list)
+
+    for probability, target, breast_id in zip(probabilities, targets, breast_ids):
+        grouped_probabilities[breast_id].append(probability)
+        grouped_targets[breast_id].append(target)
+
+    mean_targets: list[int] = []
+    mean_probabilities: list[float] = []
+    for breast_id in sorted(grouped_probabilities):
+        target_values = grouped_targets[breast_id]
+        if len(set(target_values)) != 1:
+            raise ValueError(f"Inconsistent targets found for breast_id '{breast_id}'.")
+        mean_targets.append(target_values[0])
+        mean_probabilities.append(float(sum(grouped_probabilities[breast_id]) / len(grouped_probabilities[breast_id])))
+
+    return mean_targets, mean_probabilities

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -1,0 +1,187 @@
+﻿from __future__ import annotations
+
+import csv
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+import uuid
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+import numpy as np
+import torch
+from PIL import Image
+from torch import nn
+
+from src.data import SINGLE_IMAGE_FIELDS
+from src.models.baseline import MinimalSingleImageCNN
+from src.train.trainer import build_single_image_loaders, validate_one_epoch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_TMP_ROOT = REPO_ROOT / "outputs" / "test_tmp"
+
+
+class TrainingSmokeTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        TEST_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        self.root = TEST_TMP_ROOT / uuid.uuid4().hex
+        self.root.mkdir(parents=True, exist_ok=False)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_train_baseline_script_runs_end_to_end(self) -> None:
+        train_split_path, val_split_path, archive_path = self.write_split_inputs(
+            train_specs=[("A_L", 0), ("B_R", 1), ("C_L", 0), ("D_R", 1)],
+            val_specs=[("E_L", 0), ("F_R", 1)],
+        )
+        output_dir = self.root / "baseline_output"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "train_baseline.py"),
+                "--train-split",
+                str(train_split_path),
+                "--val-split",
+                str(val_split_path),
+                "--archive-path",
+                str(archive_path),
+                "--image-size",
+                "64",
+                "--batch-size",
+                "2",
+                "--epochs",
+                "1",
+                "--output-dir",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertIn("Training finished successfully", completed.stdout)
+        self.assertTrue((output_dir / "config.json").exists())
+        self.assertTrue((output_dir / "metrics_summary.json").exists())
+        self.assertTrue((output_dir / "best_model.pt").exists())
+
+        metrics_summary = json.loads((output_dir / "metrics_summary.json").read_text(encoding="utf-8"))
+        self.assertEqual(metrics_summary["best_epoch"], 1)
+        self.assertEqual(metrics_summary["train_samples"], 8)
+        self.assertEqual(metrics_summary["val_samples"], 4)
+        self.assertIn("image_accuracy", metrics_summary["best_metrics"])
+        self.assertIn("breast_mean_accuracy", metrics_summary["best_metrics"])
+        self.assertIsNotNone(metrics_summary["best_metrics"]["image_auroc"])
+        self.assertIsNotNone(metrics_summary["best_metrics"]["breast_mean_auroc"])
+
+    def test_validate_one_epoch_returns_none_for_single_class_auroc(self) -> None:
+        train_split_path, val_split_path, archive_path = self.write_split_inputs(
+            train_specs=[("A_L", 0), ("B_R", 1)],
+            val_specs=[("C_L", 0), ("D_R", 0)],
+        )
+        loaders = build_single_image_loaders(
+            train_split_csv_path=train_split_path,
+            val_split_csv_path=val_split_path,
+            archive_path=archive_path,
+            image_size=64,
+            batch_size=2,
+            num_workers=0,
+        )
+
+        try:
+            model = MinimalSingleImageCNN(in_channels=3)
+            criterion = nn.BCEWithLogitsLoss()
+            metrics = validate_one_epoch(
+                model=model,
+                loader=loaders.val_loader,
+                criterion=criterion,
+                device=torch.device("cpu"),
+            )
+        finally:
+            loaders.close()
+
+        self.assertIsNone(metrics["image_auroc"])
+        self.assertIsNone(metrics["breast_mean_auroc"])
+        self.assertEqual(metrics["num_val_images"], 4)
+        self.assertEqual(metrics["num_val_breasts"], 2)
+
+    def write_split_inputs(
+        self,
+        train_specs: list[tuple[str, int]],
+        val_specs: list[tuple[str, int]],
+    ) -> tuple[Path, Path, Path]:
+        archive_path = self.root / "train_img.zip"
+        train_split_path = self.root / "train_split.csv"
+        val_split_path = self.root / "val_split.csv"
+
+        train_rows = self.build_rows(train_specs)
+        val_rows = self.build_rows(val_specs)
+
+        self.write_archive(archive_path, train_rows + val_rows)
+        self.write_csv(train_split_path, train_rows)
+        self.write_csv(val_split_path, val_rows)
+        return train_split_path, val_split_path, archive_path
+
+    def build_rows(self, specs: list[tuple[str, int]]) -> list[dict[str, str]]:
+        rows: list[dict[str, str]] = []
+        for breast_id, label in specs:
+            laterality = breast_id.split("_")[-1]
+            pathology = "M" if label == 1 else "N"
+            birads = "4C" if label == 1 else "1"
+            for view in ("CC", "MLO"):
+                rows.append(
+                    {
+                        "image_id": f"{breast_id}_{view}",
+                        "breast_id": breast_id,
+                        "view": view,
+                        "pathology": pathology,
+                        "is_malignant": str(label),
+                        "image_path": f"train_img/{breast_id}/{breast_id}_{view}.jpg",
+                        "laterality": laterality,
+                        "device": "HLG",
+                        "lesion_type": "",
+                        "birads": birads,
+                        "difficult": "N",
+                        "annotations": "[]",
+                    }
+                )
+        return rows
+
+    def write_archive(self, archive_path: Path, rows: list[dict[str, str]]) -> None:
+        with ZipFile(archive_path, "w") as archive:
+            for row in rows:
+                label = int(row["is_malignant"])
+                bright_left = row["view"] == "CC"
+                pixels = self.make_rgb_image(width=32, height=40, label=label, bright_left=bright_left)
+                archive.writestr(row["image_path"], self.encode_image(pixels))
+
+    def write_csv(self, path: Path, rows: list[dict[str, str]]) -> None:
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=SINGLE_IMAGE_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def make_rgb_image(self, width: int, height: int, label: int, bright_left: bool) -> np.ndarray:
+        pixels = np.zeros((height, width), dtype=np.uint8)
+        pixels[2:-2, 2:-2] = 30 if label == 0 else 150
+        if bright_left:
+            pixels[6:-6, 3 : width // 2] = 220 if label == 1 else 90
+        else:
+            pixels[6:-6, width // 2 : -3] = 220 if label == 1 else 90
+        return np.repeat(pixels[:, :, None], 3, axis=2)
+
+    def encode_image(self, rgb_pixels: np.ndarray) -> bytes:
+        image = Image.fromarray(rgb_pixels)
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG")
+        return buffer.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
what:
- implement Stage 1 Issue 1.4 minimal train/val baseline on top of the reusable single-image split artifacts
- add a compact CNN baseline, train and validation loops, image-level metrics, and lightweight breast-level mean aggregation metrics
- add a runnable training script plus smoke tests for end-to-end training and AUROC fallback behavior

why:
- establish the first runnable training-validation loop for M1
- provide a stable baseline path that reuses the existing data and split pipeline without expanding into a heavier paired-model or evaluator framework