### PR TITLE
feat(train | stage1-4_patch1): align checkpoint selection with breast-level validation priority

### DIFF
--- a/docs/ai/feedback/stage1/feedback_stage1-4.md
+++ b/docs/ai/feedback/stage1/feedback_stage1-4.md
@@ -1,0 +1,129 @@
+1. 修改了哪些文件
+
+- [src/models/baseline.py](d:/MyProject/Breast-Cancer-Detection-Model/src/models/baseline.py)
+- [src/models/__init__.py](d:/MyProject/Breast-Cancer-Detection-Model/src/models/__init__.py)
+- [src/train/trainer.py](d:/MyProject/Breast-Cancer-Detection-Model/src/train/trainer.py)
+- [src/train/__init__.py](d:/MyProject/Breast-Cancer-Detection-Model/src/train/__init__.py)
+- [scripts/train_baseline.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/train_baseline.py)
+- [tests/test_training_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_training_smoke.py)
+
+实际运行生成了：
+- [config.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/config.json)
+- [metrics_summary.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/metrics_summary.json)
+- [best_model.pt](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/best_model.pt)
+
+2. 每个文件的作用
+
+- [baseline.py](d:/MyProject/Breast-Cancer-Detection-Model/src/models/baseline.py)：定义最小单图 CNN baseline。
+- [trainer.py](d:/MyProject/Breast-Cancer-Detection-Model/src/train/trainer.py)：实现 dataloader 构建、`pos_weight` 计算、train loop、val loop、image-level 指标和轻量 breast mean aggregation 指标。
+- [train_baseline.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/train_baseline.py)：最小训练入口，读取 Issue 1.3 的 split CSV，训练 1 个单图 baseline，并保存 config、summary、checkpoint。
+- [test_training_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_training_smoke.py)：覆盖 CLI 端到端 smoke 和单类验证集 AUROC 安全退化。
+- 两个 `__init__.py`：只做最小导出，方便后续复用。
+
+3. baseline 模型是什么，为什么这样选
+
+模型是一个自定义 `MinimalSingleImageCNN`，结构是 4 个下采样卷积块，通道数固定 `16 -> 32 -> 64 -> 128`，最后接全局平均池化和线性分类头，输出单个 binary logit。
+
+这样选的原因是：
+- 当前环境实际是 CPU，先保证稳定可跑
+- 不依赖重型预训练 backbone
+- 和当前 `SingleImageDataset`、3 通道灰度复制输入完全兼容
+- 结构足够清楚，后续 Issue 1.5 / 更后面的 paired 主线可以平滑替换模型而不动训练骨架
+
+4. train/val loop 做了什么
+
+- train loop：
+  - 从 Issue 1.3 的 single-image split CSV 构建 train dataloader
+  - 前向、`BCEWithLogitsLoss`、反向传播、Adam 更新
+  - 按 epoch 汇总 `train_loss`
+- val loop：
+  - 读取 val split
+  - 计算 `val_loss`
+  - 计算 image-level `accuracy` 和 `AUROC`
+  - 收集 `breast_id`，把同一 breast 的两张图概率取平均
+  - 额外计算 `breast_mean_accuracy` 和 `breast_mean_auroc`
+- checkpoint：
+  - 按 `val_loss` 选 best
+  - 保存 `best_model.pt`
+
+5. 使用了哪些指标
+
+- `train_loss`
+- `val_loss`
+- `image_accuracy`
+- `image_auroc`
+- 轻量附加项：
+  - `breast_mean_accuracy`
+  - `breast_mean_auroc`
+
+如果某次验证集只有单类，AUROC 会返回 `None`，不会中断训练。
+
+6. 如何运行最小训练
+
+真实数据 smoke 建议这样跑：
+
+```bash
+python scripts/train_baseline.py --epochs 1 --batch-size 8 --image-size 512
+```
+
+默认接口仍保留：
+- `--train-split`
+- `--val-split`
+- `--archive-path`
+- `--image-root`
+- `--image-size`
+- `--batch-size`
+- `--epochs`
+- `--lr`
+- `--seed`
+- `--num-workers`
+- `--output-dir`
+
+7. 给出一次实际运行输出示例
+
+```text
+Epoch 1/1 train_loss=1.0648 val_loss=1.0770 image_acc=0.2462 image_auroc=0.4482 breast_mean_acc=0.2462 breast_mean_auroc=0.4225
+Training finished successfully
+- best epoch: 1
+- best val loss: 1.0770
+- wrote: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_baseline\config.json
+- wrote: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_baseline\metrics_summary.json
+- wrote: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_baseline\best_model.pt
+```
+
+8. 输出结果保存到哪里
+
+默认保存到 [outputs/m1_baseline](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline)：
+
+- [config.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/config.json)
+- [metrics_summary.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/metrics_summary.json)
+- [best_model.pt](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/best_model.pt)
+
+9. 做了哪些 smoke test / 单元测试
+
+已实际通过：
+
+```bash
+python -m unittest tests.test_index_builder tests.test_datasets tests.test_splits tests.test_training_smoke
+```
+
+新增的训练相关测试覆盖了：
+- `train_baseline.py` CLI 端到端 1 epoch smoke
+- 配置、summary、checkpoint 落盘
+- 单类验证集时 `image_auroc` / `breast_mean_auroc` 返回 `None`
+
+还实际跑通了真实数据 smoke：
+
+```bash
+python scripts/train_baseline.py --epochs 1 --batch-size 8 --image-size 512
+```
+
+10. 明确说明有哪些假设、限制或待确认点
+
+- `docs/plan/issue_stage1.md` 仍不存在；这次继续按你的规则使用了 [issue_stage1.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/gitflow/issue/issue_stage1.md)。
+- 当前环境实际只有 CPU，所以真实 smoke 用了 `--image-size 512`；代码默认值仍保留 `1024`，但在 CPU 上会更慢。
+- 当前 baseline 是 single-image image-level 训练闭环，不是 paired breast-level 主线训练。
+- 我补了轻量的 `breast_id` mean aggregation 验证指标，但没有引入完整 evaluator 框架，没有越界到 Issue 1.5。
+- 真实 smoke 的指标现在只是“能跑通”的基线，不代表效果已经合理；当前任务重点是训练-验证闭环首次成立。
+
+如果你下一步要按 issue 粒度提交，我也可以继续给你补一份 Issue 1.4 对应的 `git add` 命令和标准三段 commit 信息。

--- a/docs/ai/prompt/stage1/prompt_stage1-3.md
+++ b/docs/ai/prompt/stage1/prompt_stage1-3.md
@@ -1,0 +1,154 @@
+你现在继续为乳腺癌检测课程项目实现 Milestone 1 的 Issue 1.3。
+
+当前项目上下文：
+- Milestone: M1 — Minimal Runnable Pipeline
+- 已完成：
+  - Issue 1.1：dataset index 与 paired breast-level samples
+  - Issue 1.2：minimal preprocessing、dataset loading、dataloader smoke test
+- 当前要做：
+  - Issue 1.3：Implement breast_id-grouped train/val split and reusable split artifacts
+
+开始前你必须先阅读并遵守以下内容：
+1. docs/plan/minimal_system_design.md
+2. docs/gitflow/issue/issue_stage1.md（若 docs/plan/issue_stage1.md 不存在，则以等价文档为准）
+3. src/data/index_builder.py 及 Issue 1.1 生成的索引文件
+4. src/data/datasets.py 与 transforms.py，理解当前 single / paired dataset 的输入字段
+5. data/processed/metadata/ 下的 primary_single_image_index.csv 与 primary_paired_breast_index.csv
+
+如果仓库实际路径与文档不一致，不要臆造，基于仓库现状做最小合理适配，并在最终汇报中明确指出差异。
+
+================================
+一、任务背景与冻结约束
+================================
+
+当前主任务是 mammography breast-level malignant probability prediction。
+
+冻结约束如下：
+- pathology == "M" -> is_malignant = 1
+- pathology in {"B", "N"} -> is_malignant = 0
+- 同一 breast_id 下有两张图（CC + MLO）
+- 所有训练/验证划分必须以 breast_id 为 group
+- 绝对不能出现同一个 breast_id 同时出现在 train 和 val 中
+- Milestone 1 的目标是建立最小可运行闭环，不做复杂多折实验框架
+
+Issue 1.3 的目标是：
+基于 Issue 1.1 的 paired breast-level index，实现可复用、可检查、可落盘的 train/val split 机制，并让 single-image 与 paired 两种视图都能共享这一 split。
+
+================================
+二、本次只允许做的内容
+================================
+
+本次允许做的事情：
+1. 基于 paired breast-level index 生成 breast_id 级别的 train/val split
+2. 保证 train/val 之间 breast_id 严格不泄漏
+3. 生成 paired 视图可直接使用的 split 文件
+4. 生成 single-image 视图可直接使用的 split 文件（基于同一 breast_id 划分映射）
+5. 输出 split 统计信息与检查报告
+6. 提供一个最小脚本，方便重复生成 split
+7. 提供最小测试，验证没有 leakage、样本数合理、标签分布可检查
+
+本次不允许做的事情：
+- 不实现训练脚本
+- 不实现 AUROC / accuracy 评估
+- 不实现 k-fold / cross-validation 大框架
+- 不引入复杂实验管理系统
+- 不修改 Issue 1.1 / 1.2 的主体逻辑，除非是完成本 issue 所必需的小修补
+
+================================
+三、split 设计原则（必须遵守）
+================================
+
+1. split 的基本分组单位必须是 breast_id
+2. single-image split 不能自己重新随机划分，必须从 breast-level split 映射得到
+3. paired 与 single 两种视图必须共享同一套 train/val 边界
+4. 必须显式检查 leakage
+5. 必须输出基础统计，便于人工确认 split 是否合理
+
+你可以使用简单的 holdout 方案，例如：
+- train / val = 80 / 20
+或文档/仓库已有约定的比例
+
+如无强制文档要求，优先使用一个简单、稳定、可复现的随机种子方案。
+
+================================
+四、推荐实现目标
+================================
+
+建议在 src/data/ 或 scripts/ 下实现最小 split 机制。
+
+建议但不强制的产物结构：
+- src/data/splits.py
+- scripts/build_splits.py
+- tests/test_splits.py
+- data/processed/splits/ 下保存生成的 split 文件
+- outputs/reports/ 或 data/processed/metadata/ 下保存 split summary
+
+建议至少生成以下产物：
+
+A. paired_breast_split_train.csv
+B. paired_breast_split_val.csv
+C. single_image_split_train.csv
+D. single_image_split_val.csv
+E. split_summary.json 或 split_report.json
+
+文件命名可按仓库风格调整，但必须清晰可复用。
+
+================================
+五、必须做的检查
+================================
+
+请显式检查并汇报：
+
+1. train 和 val 的 breast_id 集合是否完全不相交
+2. single-image train/val 是否由 paired split 映射而来，而不是单独随机
+3. paired split 后每个样本是否仍保持 CC/MLO 完整
+4. train / val 的 malignant vs non-malignant 分布
+5. train / val 的 image 数、breast 数
+6. 是否存在空 split、极端失衡或异常情况
+
+如果你能在不复杂化实现的前提下做简单的 stratified group split，可以做；
+如果当前阶段不方便稳定实现，也可以先做普通 group split，但必须明确说明标签分布结果。
+
+================================
+六、最小验收标准
+================================
+
+你提交的实现必须满足：
+
+1. train/val split 严格按 breast_id 分组
+2. 没有任何 breast_id leakage
+3. paired 与 single 视图共享同一 train/val 边界
+4. 输出可复用的 split 文件
+5. 有基础统计和检查结果
+6. 有最小脚本和测试
+7. 不越界实现 Issue 1.4 / 1.5
+
+================================
+七、对前面 issue 的允许小修补
+================================
+
+如果为了完成 Issue 1.3，必须对 Issue 1.1 / 1.2 做极小修补，可以做，但仅限：
+- 补充字段常量导出
+- 增加索引读取辅助函数
+- 修正明显影响 split 构建的小问题
+
+不要借机重构 datasets / transforms / index builder。
+
+================================
+八、你最终需要返回给我的内容
+================================
+
+请按以下格式汇报：
+
+1. 修改了哪些文件
+2. 每个文件的作用
+3. split 的分组单位是什么
+4. split 是如何保证 paired / single 边界一致的
+5. 输出了哪些 split 文件，保存到哪里
+6. 做了哪些 leakage 检查
+7. train / val 的 breast 数、image 数、标签分布统计
+8. 给出最小运行方式
+9. 给出一次实际输出示例
+10. 明确说明有哪些假设、限制或待确认点
+
+如果你发现仓库中的标签分布太不均衡，导致简单 holdout 结果不理想，请不要直接扩展成复杂实验框架。请先保持 M1 最小实现，只需在汇报中明确说明当前 split 的性质与局限。

--- a/docs/ai/prompt/stage1/prompt_stage1-4.md
+++ b/docs/ai/prompt/stage1/prompt_stage1-4.md
@@ -1,0 +1,161 @@
+你现在继续为乳腺癌检测课程项目实现 Milestone 1 的 Issue 1.4。
+
+当前项目上下文：
+- Milestone: M1 — Minimal Runnable Pipeline
+- 已完成：
+  - Issue 1.1：dataset index 与 paired breast-level samples
+  - Issue 1.2：minimal preprocessing、dataset loading、dataloader smoke test
+  - Issue 1.3：breast_id-grouped train/val split and reusable split artifacts
+- 当前要做：
+  - Issue 1.4：Implement minimal train/val loop for a runnable baseline
+
+开始前你必须先阅读并遵守以下内容：
+1. docs/plan/minimal_system_design.md
+2. docs/gitflow/issue/issue_stage1.md（若 docs/plan/issue_stage1.md 不存在，则以等价文档为准）
+3. src/data/index_builder.py、src/data/datasets.py、src/data/transforms.py、src/data/splits.py
+4. data/processed/splits/ 下的 split artifacts
+5. 现有 scripts/ 下与数据检查相关的脚本，避免重复造轮子
+
+如果仓库实际路径与文档不一致，不要臆造，基于仓库现状做最小合理适配，并在最终汇报中明确指出差异。
+
+================================
+一、任务背景与冻结约束
+================================
+
+当前主任务是 mammography breast-level malignant probability prediction。
+
+冻结约束如下：
+- pathology == "M" -> is_malignant = 1
+- pathology in {"B", "N"} -> is_malignant = 0
+- 主线预测单位最终是 breast-level
+- 但 Milestone 1 的保底可运行路线允许先做 single-image baseline
+- 数据划分必须复用 Issue 1.3 的 breast_id-grouped split
+- 当前阶段目标是建立最小可运行训练/验证闭环，不追求最优模型与最优结果
+
+Issue 1.4 的目标是：
+基于已有 split 和 dataset，实现一个最小、稳定、可复现的 train/val baseline，使项目第一次具备完整的“训练—验证”运行能力。
+
+================================
+二、本次只允许做的内容
+================================
+
+本次允许做的事情：
+1. 实现一个最小 baseline 模型
+2. 实现 train loop 与 val loop
+3. 从已有 split 文件构建 dataloader
+4. 计算最小基础指标
+5. 保存最小训练输出与结果摘要
+6. 提供一个可直接运行的训练脚本
+7. 提供最小 smoke test 或 sanity check
+
+本次不允许做的事情：
+- 不实现复杂 backbone 搜索
+- 不引入大规模实验管理系统
+- 不引入复杂超参数搜索
+- 不做 cross-validation 框架
+- 不做 detection / segmentation / ROI 分支
+- 不提前扩展到完整 paper-style pipeline
+- 不大改 Issue 1.1 / 1.2 / 1.3 已有实现
+
+================================
+三、baseline 设计原则（必须遵守）
+================================
+
+Milestone 1 当前优先目标是“先跑通”，不是“先做强”。
+
+请优先实现一个最小且稳定的 single-image classification baseline：
+- 输入：SingleImageDataset
+- 标签：is_malignant
+- 输出：binary logit / probability
+- loss：标准二分类损失（如 BCEWithLogitsLoss）
+- metric：至少包含 val loss 与一个基础分类指标
+
+模型选择原则：
+- 优先简单、稳定、依赖少
+- 不要一上来接很重的预训练大模型
+- 可以使用一个很小的 CNN，或极轻量 torchvision backbone（若仓库依赖允许且实现更稳）
+- 关键是可运行、可验证、结构清晰
+
+================================
+四、关于验证与指标的要求
+================================
+
+当前阶段至少要有：
+1. train loss
+2. val loss
+3. 一个基础二分类指标，例如 accuracy
+4. 最好再加 AUROC；若当前依赖或样本情况不稳定，可先不强制，但要说明
+
+注意：
+- 当前 split 是 breast_id-grouped 的，所以 image-level val 指标至少不会有明显 leakage
+- 但当前 baseline 如果是 single-image classifier，那么它本质上仍是 image-level prediction
+- 你可以先实现 image-level 验证闭环
+- 若实现成本不高，欢迎顺手补一个基于 breast_id 的 mean aggregation 验证函数，把同一 breast 的两张图概率做平均后再算 breast-level metric；但这不是强制项，不能因此拖慢主线
+
+================================
+五、推荐实现目标
+================================
+
+建议但不强制的文件结构：
+- src/models/baseline.py 或 src/models/classifier.py
+- src/engine/trainer.py 或 src/training/train_loop.py
+- scripts/train_baseline.py
+- tests/test_training_smoke.py
+- outputs/m1_baseline/ 或 runs/m1_baseline/ 下保存结果
+
+训练脚本至少应支持：
+- 指定 train split csv
+- 指定 val split csv
+- batch size
+- epochs
+- image size（若当前数据 pipeline 已固定，可不暴露太多参数）
+- random seed
+- output dir
+
+结果产物建议至少包括：
+- config / args 保存
+- 最后一轮或最佳轮的 metrics summary
+- 简单日志
+- 可选：best model checkpoint
+
+================================
+六、最小验收标准
+================================
+
+你提交的实现必须满足：
+
+1. 能基于 Issue 1.3 的 split 文件正常构建 train/val dataloader
+2. 能完整跑通至少 1 个 epoch 的训练与验证
+3. 能输出 train loss、val loss 和至少一个基础指标
+4. 结果文件有明确保存位置
+5. 有最小脚本和测试 / smoke test
+6. 不越界实现 Issue 1.5 或更后面的复杂内容
+
+================================
+七、实现风格要求
+================================
+
+1. 先追求稳定和清晰，不追求复杂和“高级感”
+2. train loop、val loop、metric 计算尽量分层清楚
+3. 不要把数据加载、模型定义、训练逻辑、CLI 全部糊在一个文件里
+4. 保持后续 Issue 1.5 可以平滑接入 breast-level aggregation / evaluation
+5. 如果你顺手实现了 breast-level mean aggregation metric，请保持它是轻量附加能力，而不是把整个 issue 重心带偏
+
+================================
+八、你最终需要返回给我的内容
+================================
+
+请按以下格式汇报：
+
+1. 修改了哪些文件
+2. 每个文件的作用
+3. baseline 模型是什么，为什么这样选
+4. train/val loop 做了什么
+5. 使用了哪些指标
+6. 如何运行最小训练
+7. 给出一次实际运行输出示例
+8. 输出结果保存到哪里
+9. 做了哪些 smoke test / 单元测试
+10. 明确说明有哪些假设、限制或待确认点
+
+如果你判断当前阶段加入 breast-level mean aggregation 验证非常低成本且有益，可以实现；但请把它作为“轻量附加项”，不要因此引入复杂 evaluator 框架。当前主任务仍然是先建立最小训练/验证闭环。

--- a/docs/ai/prompt/stage1/prompt_stage1-4_patch1.md
+++ b/docs/ai/prompt/stage1/prompt_stage1-4_patch1.md
@@ -1,0 +1,104 @@
+你现在不要进入下一个大 issue，先对 Milestone 1 的 Issue 1.4 做一次小修补（Issue 1.4.x）。
+
+当前状态：
+- Issue 1.4 已经实现了最小 single-image baseline、train/val loop、image-level metric，以及轻量 breast mean aggregation metric
+- 当前 best checkpoint 是按 val_loss 选择的
+- 但项目冻结主任务是 breast-level malignant probability prediction
+- 已经有 breast_mean_accuracy / breast_mean_auroc，因此当前 model selection 与主任务目标还不够对齐
+
+本次修补目标：
+在不重构训练框架、不扩展到完整 evaluator 框架的前提下，补齐一个“与主任务更对齐”的 checkpoint 选择与 summary 记录机制。
+
+================================
+一、修补范围
+================================
+
+只允许做以下小修补：
+1. 给训练逻辑增加显式的 selection metric 机制
+2. 调整 best checkpoint 选择逻辑
+3. 增强 metrics_summary.json 的结构化记录
+4. 补充最小测试，覆盖 selection metric/fallback 行为
+5. 如有必要，增加非常小的 CLI 参数（例如 --selection-metric）
+
+不要做以下事情：
+- 不重构整个 trainer
+- 不扩展成复杂 evaluator 框架
+- 不改模型结构
+- 不改 dataset / split / transforms 主体逻辑
+- 不进入 Issue 1.5 的正式 breast-level evaluator 开发
+
+================================
+二、你必须实现的选择逻辑
+================================
+
+请实现一个清晰的 model selection 机制，推荐默认规则如下：
+
+优先级：
+1. 如果 breast_mean_auroc 可用（不是 None），则默认用它作为 best checkpoint 选择指标，方向是越大越好
+2. 如果 breast_mean_auroc 不可用，则回退到 image_auroc，方向越大越好
+3. 如果 image_auroc 也不可用，则回退到 val_loss，方向越小越好
+
+你可以把这个逻辑封装成独立函数，避免散落在 train loop 里。
+
+如你认为更合适，也可以支持 CLI 参数：
+- --selection-metric auto
+- --selection-metric breast_mean_auroc
+- --selection-metric image_auroc
+- --selection-metric val_loss
+
+但默认必须是一个合理的 auto 模式，而且要和上述优先级一致。
+
+================================
+三、metrics summary 的增强要求
+================================
+
+请确保输出的 metrics_summary.json 至少清楚记录：
+
+1. primary_selection_metric
+2. selection_mode（如 auto / explicit）
+3. best_epoch
+4. best_metric_name
+5. best_metric_value
+6. 若发生 fallback，记录 fallback_used=true/false
+7. 若发生 fallback，记录 fallback_reason
+8. 每个 epoch 的：
+   - train_loss
+   - val_loss
+   - image_accuracy
+   - image_auroc
+   - breast_mean_accuracy
+   - breast_mean_auroc
+
+不要只保存最终一行 summary，要保证后续人工复查时能看出 best checkpoint 是怎么选出来的。
+
+================================
+四、测试要求
+================================
+
+请至少补充以下测试之一或多项：
+
+1. 当 breast_mean_auroc 存在时，best checkpoint 按 breast_mean_auroc 选择
+2. 当 breast_mean_auroc 为 None、image_auroc 存在时，自动回退到 image_auroc
+3. 当两个 AUROC 都不可用时，自动回退到 val_loss
+4. metrics_summary.json 中正确记录了 primary_selection_metric 与 fallback 信息
+
+测试尽量保持小而直接，不要引入复杂测试夹具。
+
+================================
+五、你最终需要返回给我的内容
+================================
+
+请按以下格式汇报：
+
+1. 修改了哪些文件
+2. 每个修改的作用
+3. best checkpoint 选择逻辑现在是什么
+4. 默认 selection metric 是什么，为什么
+5. fallback 机制是什么
+6. metrics_summary.json 新增了哪些字段
+7. 补了哪些测试
+8. 给出一次最小运行方式
+9. 给出一段新的 summary 输出示例
+10. 明确说明这次修补没有越界到 Issue 1.5
+
+如果你发现现有 trainer 结构里很难优雅地加入这个逻辑，请做最小合理改动，不要为了“优雅”而扩大改动范围。当前任务就是一个轻量修补。

--- a/docs/ai/prompt/stage1/prompt_stage1-5.md
+++ b/docs/ai/prompt/stage1/prompt_stage1-5.md
@@ -1,0 +1,142 @@
+你现在继续为乳腺癌检测课程项目实现 Milestone 1 的 Issue 1.5。
+
+当前唯一权威的 issue 定义来源是：
+- Stage 1 Issue Plan / issue_stage1.md
+
+请先阅读并严格遵守其中对 Issue 1.5 的定义，不要自行改写 issue 目标。你还必须结合以下文档与现有实现：
+1. docs/plan/minimal_system_design.md
+2. issue_stage1.md 中 Issue 1.5 的原始要求
+3. 当前已完成的 Issue 1.1–1.4 / 1.4.x 相关实现
+4. Issue 1.3 的 split artifacts
+5. 当前 train/val 输出结构与 checkpoint / metrics summary 结构
+
+如果仓库实际路径与文档不一致，不要臆造，基于仓库现状做最小合理适配，并在最终汇报中明确指出差异。
+
+================================
+一、严格按原 issue 定义执行
+================================
+
+Issue 1.5 的原始定义是：
+
+Title:
+Create Minimal Evaluation and Breast-level Aggregation Skeleton
+
+Goal:
+建立最小评估脚本框架，支持从验证输出中完成 breast-level 聚合与 AUROC 计算。
+
+Scope:
+- 收集 image-level 或 pair-level 预测结果
+- 实现基于 breast_id 的聚合接口
+- 支持 mean / max 等基本聚合方式
+- 计算 AUROC
+- 保存验证结果表
+
+Deliverables:
+- src/eval/ 下的最小评估模块
+- AUROC 计算逻辑
+- breast-level prediction 导出文件
+- 简单的评估入口脚本
+
+Acceptance Criteria:
+- 能对一份预测结果表正确完成 breast_id 聚合
+- 能输出 breast-level AUROC
+- 结果文件中包含 breast_id, target, prediction 等关键字段
+- 评估逻辑可被 M2 正式 baseline 直接复用
+
+你必须以这些要求为准，不要把本 issue 扩展成复杂实验平台。
+
+================================
+二、本次允许做的内容
+================================
+
+1. 从当前验证输出中收集预测结果
+2. 实现独立、清晰的 breast-level aggregation 接口
+3. 至少支持 mean 聚合，并尽量顺手支持 max 聚合
+4. 实现 AUROC 计算与单类安全退化
+5. 导出 breast-level prediction 文件
+6. 提供一个最小 evaluation 入口脚本
+7. 提供最小测试，验证聚合和 AUROC 逻辑
+
+================================
+三、本次不允许做的内容
+================================
+
+1. 不重构整个训练框架
+2. 不扩展成复杂 evaluator framework
+3. 不开始 paired 双分支训练
+4. 不进入 Milestone 2 的正式 baseline 工程
+5. 不大改 Issue 1.4 的训练主骨架
+6. 不引入多种复杂 aggregation 策略搜索
+
+================================
+四、实现要求
+================================
+
+请尽量在 src/eval/ 下组织最小评估模块，保持与原 issue deliverables 一致。
+
+建议但不强制的实现方向：
+- src/eval/aggregation.py
+- src/eval/metrics.py
+- scripts/run_eval.py 或等价入口
+- 输出 breast_level_predictions.csv
+- 输出 breast_level_metrics.json
+
+聚合输入不要被写死为 single-image only。
+当前主来源可以是 image-level prediction，但接口层面应允许“对一份预测结果表”进行聚合，这样后续更容易复用到 pair-level 输出。
+
+聚合要求：
+- 按 breast_id 分组
+- target 在同组内必须一致，否则报错
+- 至少支持 aggregation = mean
+- 最好支持 aggregation = max
+- 输出中至少包含：
+  - breast_id
+  - target
+  - prediction
+  - num_items_aggregated
+
+指标要求：
+- 计算 breast-level AUROC
+- 若 target 只有单类，必须安全退化并明确记录
+
+================================
+五、最小验收标准
+================================
+
+你的实现必须满足：
+
+1. 能对一份预测结果表正确完成 breast_id 聚合
+2. 能输出 breast-level AUROC
+3. 结果文件中包含 breast_id、target、prediction 等关键字段
+4. 有独立、清晰、可复用的最小评估模块
+5. 有简单评估入口脚本
+6. 评估逻辑可被 M2 正式 baseline 直接复用
+7. 不越界扩展到复杂评估平台
+
+================================
+六、测试要求
+================================
+
+请补充最小测试，至少覆盖：
+1. mean 聚合正确
+2. max 聚合正确（如果你实现了）
+3. 同一 breast_id 内 target 不一致时报错
+4. AUROC 单类时安全退化
+5. 评估 artifact 成功生成
+
+================================
+七、最终汇报格式
+================================
+
+请按以下格式返回：
+
+1. 修改了哪些文件
+2. 每个文件的作用
+3. aggregation 接口支持哪些输入与聚合方式
+4. AUROC 如何计算，单类时如何处理
+5. 输出了哪些结果文件，保存到哪里
+6. 简单评估入口脚本如何运行
+7. 给出一次最小运行示例
+8. 给出一段实际输出示例
+9. 补了哪些测试
+10. 明确说明这次实现如何对应 issue_stage1.md 中 Issue 1.5 的原始 Goal / Scope / Deliverables / Acceptance Criteria

--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 from src.data.datasets import DEFAULT_ARCHIVE_PATH  # noqa: E402
 from src.models.baseline import MinimalSingleImageCNN  # noqa: E402
 from src.train.trainer import (  # noqa: E402
+    SELECTION_METRIC_CHOICES,
     build_single_image_loaders,
     compute_pos_weight,
     fit,
@@ -43,6 +44,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--num-workers", type=int, default=0)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--selection-metric", choices=SELECTION_METRIC_CHOICES, default="auto")
     return parser.parse_args()
 
 
@@ -67,6 +69,7 @@ def main() -> int:
         "num_workers": args.num_workers,
         "device": str(device),
         "model": "MinimalSingleImageCNN",
+        "selection_metric": args.selection_metric,
     }
     write_json(output_dir / "config.json", config)
 
@@ -97,6 +100,7 @@ def main() -> int:
             device=device,
             epochs=args.epochs,
             output_dir=output_dir,
+            selection_metric=args.selection_metric,
         )
     finally:
         loader_bundle.close()
@@ -106,7 +110,13 @@ def main() -> int:
         "train_samples": len(loader_bundle.train_dataset),
         "val_samples": len(loader_bundle.val_dataset),
         "pos_weight": pos_weight,
+        "primary_selection_metric": fit_result["primary_selection_metric"],
+        "selection_mode": fit_result["selection_mode"],
         "best_epoch": fit_result["best_epoch"],
+        "best_metric_name": fit_result["best_metric_name"],
+        "best_metric_value": fit_result["best_metric_value"],
+        "fallback_used": fit_result["fallback_used"],
+        "fallback_reason": fit_result["fallback_reason"],
         "best_metrics": fit_result["best_metrics"],
         "history": fit_result["history"],
         "best_checkpoint_path": str(fit_result["best_checkpoint_path"]),
@@ -114,8 +124,11 @@ def main() -> int:
     write_json(output_dir / "metrics_summary.json", metrics_summary)
 
     print("Training finished successfully")
+    print(f"- primary selection metric: {fit_result['primary_selection_metric']}")
     print(f"- best epoch: {fit_result['best_epoch']}")
-    print(f"- best val loss: {fit_result['best_metrics']['val_loss']:.4f}")
+    print(f"- best metric: {fit_result['best_metric_name']}={format_metric_value(fit_result['best_metric_value'])}")
+    print(f"- fallback used: {fit_result['fallback_used']}")
+    print(f"- fallback reason: {fit_result['fallback_reason'] or 'None'}")
     print(f"- wrote: {output_dir / 'config.json'}")
     print(f"- wrote: {output_dir / 'metrics_summary.json'}")
     print(f"- wrote: {fit_result['best_checkpoint_path']}")
@@ -126,6 +139,12 @@ def write_json(path: Path, payload: dict[str, object]) -> None:
     with path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, ensure_ascii=False)
         handle.write("\n")
+
+
+def format_metric_value(value: float | None) -> str:
+    if value is None:
+        return "None"
+    return f"{value:.4f}"
 
 
 if __name__ == "__main__":

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -1,21 +1,27 @@
 """Training utilities for the breast cancer detection project."""
 
 from .trainer import (
+    SELECTION_METRIC_CHOICES,
     SingleImageLoaderBundle,
     build_single_image_loaders,
     compute_pos_weight,
     fit,
+    is_better_selection,
+    resolve_selection_metric,
     set_random_seed,
     train_one_epoch,
     validate_one_epoch,
 )
 
 __all__ = [
+    "SELECTION_METRIC_CHOICES",
     "SingleImageLoaderBundle",
     "set_random_seed",
     "build_single_image_loaders",
     "compute_pos_weight",
     "train_one_epoch",
     "validate_one_epoch",
+    "resolve_selection_metric",
+    "is_better_selection",
     "fit",
 ]

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -17,6 +17,13 @@ from torch.utils.data import DataLoader
 from src.data.datasets import DEFAULT_ARCHIVE_PATH, SingleImageDataset
 from src.data.transforms import build_eval_transform, build_train_transform
 
+SELECTION_METRIC_CHOICES = ("auto", "breast_mean_auroc", "image_auroc", "val_loss")
+_SELECTION_PRIORITIES = {
+    "breast_mean_auroc": 3,
+    "image_auroc": 2,
+    "val_loss": 1,
+}
+
 
 @dataclass
 class SingleImageLoaderBundle:
@@ -185,8 +192,9 @@ def fit(
     device: torch.device,
     epochs: int,
     output_dir: str | Path,
+    selection_metric: str = "auto",
 ) -> dict[str, Any]:
-    """Run the minimal train/val loop and save the best checkpoint by val loss."""
+    """Run the minimal train/val loop and save the best checkpoint."""
 
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
@@ -194,7 +202,10 @@ def fit(
 
     history: list[dict[str, Any]] = []
     best_epoch = -1
-    best_val_loss = float("inf")
+    best_metrics: dict[str, Any] | None = None
+    best_selection: dict[str, Any] | None = None
+    selection_mode = "auto" if selection_metric == "auto" else "explicit"
+    primary_selection_metric = "breast_mean_auroc" if selection_metric == "auto" else selection_metric
 
     for epoch in range(1, epochs + 1):
         train_metrics = train_one_epoch(model, train_loader, optimizer, criterion, device)
@@ -204,6 +215,15 @@ def fit(
             **train_metrics,
             **val_metrics,
         }
+        selection_info = resolve_selection_metric(epoch_metrics, selection_metric=selection_metric)
+        epoch_metrics.update(
+            {
+                "selection_metric_name": selection_info["metric_name"],
+                "selection_metric_value": selection_info["metric_value"],
+                "selection_fallback_used": selection_info["fallback_used"],
+                "selection_fallback_reason": selection_info["fallback_reason"],
+            }
+        )
         history.append(epoch_metrics)
         print(
             "Epoch "
@@ -213,24 +233,121 @@ def fit(
             f"image_acc={epoch_metrics['image_accuracy']:.4f} "
             f"image_auroc={_format_metric_value(epoch_metrics['image_auroc'])} "
             f"breast_mean_acc={epoch_metrics['breast_mean_accuracy']:.4f} "
-            f"breast_mean_auroc={_format_metric_value(epoch_metrics['breast_mean_auroc'])}"
+            f"breast_mean_auroc={_format_metric_value(epoch_metrics['breast_mean_auroc'])} "
+            f"selection={selection_info['metric_name']}:{_format_metric_value(selection_info['metric_value'])}"
         )
 
-        if val_metrics["val_loss"] < best_val_loss:
-            best_val_loss = float(val_metrics["val_loss"])
+        if is_better_selection(selection_info, best_selection):
             best_epoch = epoch
+            best_metrics = dict(epoch_metrics)
+            best_selection = dict(selection_info)
             torch.save(model.state_dict(), checkpoint_path)
 
     if best_epoch == -1:
+        if selection_mode == "explicit":
+            raise ValueError(
+                f"Selection metric '{selection_metric}' was unavailable for every epoch. "
+                "Use --selection-metric auto or val_loss."
+            )
         raise RuntimeError("Training finished without producing any epoch metrics.")
 
-    best_metrics = next(metric for metric in history if metric["epoch"] == best_epoch)
+    if best_metrics is None or best_selection is None:
+        raise RuntimeError("Training finished without a valid best checkpoint selection.")
+
     return {
         "history": history,
         "best_epoch": best_epoch,
         "best_metrics": best_metrics,
         "best_checkpoint_path": checkpoint_path,
+        "primary_selection_metric": primary_selection_metric,
+        "selection_mode": selection_mode,
+        "best_metric_name": best_selection["metric_name"],
+        "best_metric_value": best_selection["metric_value"],
+        "fallback_used": best_selection["fallback_used"],
+        "fallback_reason": best_selection["fallback_reason"],
     }
+
+
+def resolve_selection_metric(
+    epoch_metrics: dict[str, Any],
+    selection_metric: str = "auto",
+) -> dict[str, Any]:
+    """Resolve the metric used for best-checkpoint selection for one epoch."""
+
+    if selection_metric not in SELECTION_METRIC_CHOICES:
+        raise ValueError(
+            f"Unsupported selection_metric '{selection_metric}'. "
+            f"Expected one of: {', '.join(SELECTION_METRIC_CHOICES)}."
+        )
+
+    if selection_metric == "auto":
+        breast_mean_auroc = epoch_metrics.get("breast_mean_auroc")
+        if breast_mean_auroc is not None:
+            return _build_selection_info(
+                metric_name="breast_mean_auroc",
+                metric_value=breast_mean_auroc,
+                higher_is_better=True,
+                fallback_used=False,
+                fallback_reason="",
+            )
+
+        image_auroc = epoch_metrics.get("image_auroc")
+        if image_auroc is not None:
+            return _build_selection_info(
+                metric_name="image_auroc",
+                metric_value=image_auroc,
+                higher_is_better=True,
+                fallback_used=True,
+                fallback_reason="breast_mean_auroc unavailable for this epoch.",
+            )
+
+        return _build_selection_info(
+            metric_name="val_loss",
+            metric_value=epoch_metrics["val_loss"],
+            higher_is_better=False,
+            fallback_used=True,
+            fallback_reason="breast_mean_auroc and image_auroc unavailable for this epoch.",
+        )
+
+    if selection_metric == "val_loss":
+        return _build_selection_info(
+            metric_name="val_loss",
+            metric_value=epoch_metrics["val_loss"],
+            higher_is_better=False,
+            fallback_used=False,
+            fallback_reason="",
+        )
+
+    return _build_selection_info(
+        metric_name=selection_metric,
+        metric_value=epoch_metrics.get(selection_metric),
+        higher_is_better=True,
+        fallback_used=False,
+        fallback_reason="",
+    )
+
+
+def is_better_selection(
+    candidate: dict[str, Any],
+    current_best: dict[str, Any] | None,
+) -> bool:
+    """Compare two candidate best-checkpoint selections."""
+
+    candidate_value = candidate["metric_value"]
+    if candidate_value is None:
+        return False
+    if current_best is None:
+        return True
+
+    if candidate["priority_rank"] != current_best["priority_rank"]:
+        return candidate["priority_rank"] > current_best["priority_rank"]
+
+    current_best_value = current_best["metric_value"]
+    if current_best_value is None:
+        return True
+    if candidate["higher_is_better"]:
+        return candidate_value > current_best_value
+    return candidate_value < current_best_value
 
 
 def _binary_accuracy(targets: list[int], probabilities: list[float]) -> float:
@@ -275,3 +392,20 @@ def _aggregate_breast_mean_predictions(
         mean_probabilities.append(float(sum(grouped_probabilities[breast_id]) / len(grouped_probabilities[breast_id])))
 
     return mean_targets, mean_probabilities
+
+
+def _build_selection_info(
+    metric_name: str,
+    metric_value: float | None,
+    higher_is_better: bool,
+    fallback_used: bool,
+    fallback_reason: str,
+) -> dict[str, Any]:
+    return {
+        "metric_name": metric_name,
+        "metric_value": None if metric_value is None else float(metric_value),
+        "higher_is_better": higher_is_better,
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "priority_rank": _SELECTION_PRIORITIES[metric_name],
+    }

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import csv
 import json
@@ -18,7 +18,13 @@ from torch import nn
 
 from src.data import SINGLE_IMAGE_FIELDS
 from src.models.baseline import MinimalSingleImageCNN
-from src.train.trainer import build_single_image_loaders, validate_one_epoch
+from src.train.trainer import (
+    build_single_image_loaders,
+    fit,
+    is_better_selection,
+    resolve_selection_metric,
+    validate_one_epoch,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -75,10 +81,87 @@ class TrainingSmokeTestCase(unittest.TestCase):
         self.assertEqual(metrics_summary["best_epoch"], 1)
         self.assertEqual(metrics_summary["train_samples"], 8)
         self.assertEqual(metrics_summary["val_samples"], 4)
+        self.assertEqual(metrics_summary["primary_selection_metric"], "breast_mean_auroc")
+        self.assertEqual(metrics_summary["selection_mode"], "auto")
+        self.assertEqual(metrics_summary["best_metric_name"], "breast_mean_auroc")
+        self.assertIsNotNone(metrics_summary["best_metric_value"])
+        self.assertFalse(metrics_summary["fallback_used"])
+        self.assertEqual(metrics_summary["fallback_reason"], "")
         self.assertIn("image_accuracy", metrics_summary["best_metrics"])
         self.assertIn("breast_mean_accuracy", metrics_summary["best_metrics"])
         self.assertIsNotNone(metrics_summary["best_metrics"]["image_auroc"])
         self.assertIsNotNone(metrics_summary["best_metrics"]["breast_mean_auroc"])
+        history_entry = metrics_summary["history"][0]
+        self.assertEqual(history_entry["selection_metric_name"], "breast_mean_auroc")
+        self.assertFalse(history_entry["selection_fallback_used"])
+        self.assertEqual(history_entry["selection_fallback_reason"], "")
+
+    def test_auto_selection_prefers_breast_mean_auroc(self) -> None:
+        selection = resolve_selection_metric(
+            {
+                "val_loss": 0.8,
+                "image_auroc": 0.63,
+                "breast_mean_auroc": 0.71,
+            },
+            selection_metric="auto",
+        )
+
+        self.assertEqual(selection["metric_name"], "breast_mean_auroc")
+        self.assertEqual(selection["metric_value"], 0.71)
+        self.assertTrue(selection["higher_is_better"])
+        self.assertFalse(selection["fallback_used"])
+        self.assertEqual(selection["fallback_reason"], "")
+
+    def test_auto_selection_falls_back_to_image_auroc(self) -> None:
+        selection = resolve_selection_metric(
+            {
+                "val_loss": 0.8,
+                "image_auroc": 0.63,
+                "breast_mean_auroc": None,
+            },
+            selection_metric="auto",
+        )
+
+        self.assertEqual(selection["metric_name"], "image_auroc")
+        self.assertEqual(selection["metric_value"], 0.63)
+        self.assertTrue(selection["fallback_used"])
+        self.assertIn("breast_mean_auroc unavailable", selection["fallback_reason"])
+
+    def test_auto_selection_falls_back_to_val_loss(self) -> None:
+        selection = resolve_selection_metric(
+            {
+                "val_loss": 0.42,
+                "image_auroc": None,
+                "breast_mean_auroc": None,
+            },
+            selection_metric="auto",
+        )
+
+        self.assertEqual(selection["metric_name"], "val_loss")
+        self.assertEqual(selection["metric_value"], 0.42)
+        self.assertFalse(selection["higher_is_better"])
+        self.assertTrue(selection["fallback_used"])
+        self.assertIn("image_auroc unavailable", selection["fallback_reason"])
+
+    def test_higher_priority_selection_beats_lower_priority_metric(self) -> None:
+        lower_priority = resolve_selection_metric(
+            {
+                "val_loss": 0.10,
+                "image_auroc": 0.95,
+                "breast_mean_auroc": None,
+            },
+            selection_metric="auto",
+        )
+        higher_priority = resolve_selection_metric(
+            {
+                "val_loss": 0.90,
+                "image_auroc": 0.10,
+                "breast_mean_auroc": 0.40,
+            },
+            selection_metric="auto",
+        )
+
+        self.assertTrue(is_better_selection(higher_priority, lower_priority))
 
     def test_validate_one_epoch_returns_none_for_single_class_auroc(self) -> None:
         train_split_path, val_split_path, archive_path = self.write_split_inputs(
@@ -110,6 +193,42 @@ class TrainingSmokeTestCase(unittest.TestCase):
         self.assertIsNone(metrics["breast_mean_auroc"])
         self.assertEqual(metrics["num_val_images"], 4)
         self.assertEqual(metrics["num_val_breasts"], 2)
+
+    def test_fit_raises_when_explicit_metric_is_unavailable_for_all_epochs(self) -> None:
+        train_split_path, val_split_path, archive_path = self.write_split_inputs(
+            train_specs=[("A_L", 0), ("B_R", 1)],
+            val_specs=[("C_L", 0), ("D_R", 0)],
+        )
+        loaders = build_single_image_loaders(
+            train_split_csv_path=train_split_path,
+            val_split_csv_path=val_split_path,
+            archive_path=archive_path,
+            image_size=64,
+            batch_size=2,
+            num_workers=0,
+        )
+
+        try:
+            model = MinimalSingleImageCNN(in_channels=3)
+            criterion = nn.BCEWithLogitsLoss()
+            optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+            with self.assertRaisesRegex(
+                ValueError,
+                "Selection metric 'image_auroc' was unavailable for every epoch",
+            ):
+                fit(
+                    model=model,
+                    train_loader=loaders.train_loader,
+                    val_loader=loaders.val_loader,
+                    optimizer=optimizer,
+                    criterion=criterion,
+                    device=torch.device("cpu"),
+                    epochs=1,
+                    output_dir=self.root / "explicit_metric_missing",
+                    selection_metric="image_auroc",
+                )
+        finally:
+            loaders.close()
 
     def write_split_inputs(
         self,


### PR DESCRIPTION
what:
- add an explicit selection-metric mechanism for Issue 1.4 training outputs
- switch best checkpoint selection to auto-prioritize breast_mean_auroc, then image_auroc, then val_loss
- extend metrics_summary.json and smoke tests to record and verify selection and fallback behavior

why:
- make model selection better aligned with the project’s breast-level malignant probability objective
- keep the minimal M1 training loop stable and reviewable without expanding into a full evaluation framework