### PR TITLE
feat(eval): add minimal breast-level aggregation and evaluation artifacts

### DIFF
--- a/docs/ai/feedback/stage1/feedback_stage1-5.md
+++ b/docs/ai/feedback/stage1/feedback_stage1-5.md
@@ -1,0 +1,120 @@
+1. 修改了哪些文件
+- [src/eval/aggregation.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/aggregation.py)
+- [src/eval/metrics.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/metrics.py)
+- [src/eval/pipeline.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/pipeline.py)
+- [src/eval/__init__.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/__init__.py)
+- [scripts/run_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_eval.py)
+- [tests/test_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_eval.py)
+
+2. 每个文件的作用
+- [aggregation.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/aggregation.py)：对一份 prediction rows 按 `breast_id` 聚合，支持 `mean` 和 `max`。
+- [metrics.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/metrics.py)：计算 breast-level AUROC，并处理单类安全退化。
+- [pipeline.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/pipeline.py)：收集 single-image validation predictions、构建 evaluation 结果、写出 artifact。
+- [__init__.py](d:/MyProject/Breast-Cancer-Detection-Model/src/eval/__init__.py)：导出最小评估接口。
+- [run_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_eval.py)：最小评估入口，读取 checkpoint + val split，输出 image-level 和 breast-level artifact。
+- [test_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_eval.py)：覆盖 mean/max、target 一致性、单类 AUROC、artifact 落盘。
+
+3. aggregation 接口支持哪些输入与聚合方式
+- 核心接口是 `aggregate_prediction_rows(...)`，输入是一份 prediction table，不写死为 single-image。
+- 只要求输入行里至少有：
+- `breast_id`
+- `target`
+- `prediction`
+- 可选 `image_id` 或其他 item id，用于导出可追踪引用。
+- 当前支持：
+- `mean`
+- `max`
+- 输出行至少包含：
+- `breast_id`
+- `target`
+- `prediction`
+- `num_items_aggregated`
+- `item_ids`
+
+4. AUROC 如何计算，单类时如何处理
+- 用 `sklearn.metrics.roc_auc_score` 计算二分类 AUROC。
+- 如果 breast-level `target` 只有一个类别，返回 `None`，不报错中断。
+- `breast_level_metrics.json` 会同时写：
+- `breast_auroc`
+- `auroc_available`
+- `auroc_reason`
+
+5. 输出了哪些结果文件，保存到哪里
+- 默认评估输出目录是 [outputs/m1_baseline/eval](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/eval)
+- 产物包括：
+- [image_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/eval/image_level_predictions.csv)
+- [breast_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/eval/breast_level_predictions.csv)
+- [breast_level_metrics.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline/eval/breast_level_metrics.json)
+
+6. 简单评估入口脚本如何运行
+- 脚本是 [run_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_eval.py)
+- 它会：
+- 读取 `best_model.pt`
+- 读取 val split
+- 生成 image-level prediction rows
+- 聚合成 breast-level prediction
+- 输出 breast-level AUROC 和 artifact
+
+7. 给出一次最小运行示例
+```bash
+python scripts/run_eval.py --checkpoint outputs/m1_baseline/best_model.pt --image-size 512 --output-dir outputs/m1_baseline/eval
+```
+
+8. 给出一段实际输出示例
+```text
+Evaluation finished successfully
+- checkpoint: outputs\m1_baseline\best_model.pt
+- aggregation: mean
+- image predictions: 260
+- breast predictions: 130
+- breast auroc: 0.4225
+- auroc available: True
+```
+
+`breast_level_predictions.csv` 示例：
+```text
+breast_id,target,prediction,num_items_aggregated,item_ids
+00668_R,1,0.5715279579162598,2,00668_R_CC|00668_R_MLO
+01041_R,0,0.5786077082157135,2,01041_R_CC|01041_R_MLO
+02930_R,1,0.580634742975235,2,02930_R_CC|02930_R_MLO
+```
+
+9. 补了哪些测试
+- `mean` 聚合正确
+- `max` 聚合正确
+- 同一 `breast_id` 内 `target` 不一致时报错
+- 单类 AUROC 返回 `None`
+- `image_level_predictions.csv` / `breast_level_predictions.csv` / `breast_level_metrics.json` 成功生成
+- 实际跑过：
+```bash
+python -m unittest tests.test_eval
+python -m unittest tests.test_index_builder tests.test_datasets tests.test_splits tests.test_split_fold_assignment tests.test_training_smoke tests.test_eval
+python scripts/run_eval.py --checkpoint outputs/m1_baseline/best_model.pt --image-size 512 --output-dir outputs/m1_baseline/eval
+```
+
+10. 明确说明这次实现如何对应 `issue_stage1.md` 中 Issue 1.5 的原始 Goal / Scope / Deliverables / Acceptance Criteria
+- Goal：
+  - 已建立最小评估脚本框架 [run_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_eval.py)，支持从验证预测输出中完成 breast-level 聚合和 AUROC 计算。
+- Scope：
+  - 支持收集 image-level predictions
+  - 支持基于 `breast_id` 的聚合接口
+  - 支持 `mean` / `max`
+  - 支持 AUROC 与单类安全退化
+  - 支持保存验证结果表
+- Deliverables：
+  - `src/eval/` 最小评估模块已补齐
+  - AUROC 逻辑已独立实现
+  - breast-level prediction CSV 已导出
+  - 简单评估入口脚本已提供
+- Acceptance Criteria：
+  - 可以对 prediction table 正确做 `breast_id` 聚合
+  - 可以输出 breast-level AUROC
+  - 结果文件包含 `breast_id / target / prediction`
+  - 逻辑是独立模块，可直接给 M2 复用
+- 路径差异说明：
+  - 仓库里没有 `docs/plan/issue_stage1.md`，本次按你的要求使用了等价文档 [docs/gitflow/issue/issue_stage1.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/gitflow/issue/issue_stage1.md)
+- 范围控制说明：
+  - 没有重构整个 trainer
+  - 没有引入复杂 evaluator framework
+  - 没有开始 paired 双分支训练
+  - 没有越界到 Milestone 2

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -1,0 +1,112 @@
+"""Run minimal breast-level evaluation from a validation split and checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.data.datasets import (  # noqa: E402
+    DEFAULT_ARCHIVE_PATH,
+    DEFAULT_SINGLE_INDEX_PATH,
+    SingleImageDataset,
+)
+from src.data.transforms import build_eval_transform  # noqa: E402
+from src.eval import (  # noqa: E402
+    AGGREGATION_CHOICES,
+    collect_single_image_prediction_rows,
+    evaluate_prediction_rows,
+    write_evaluation_artifacts,
+)
+from src.models.baseline import MinimalSingleImageCNN  # noqa: E402
+
+
+DEFAULT_CHECKPOINT_PATH = REPO_ROOT / "outputs" / "m1_baseline" / "best_model.pt"
+DEFAULT_VAL_SPLIT = REPO_ROOT / "data" / "processed" / "splits" / "primary_single_image_split_val.csv"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "m1_baseline" / "eval"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=DEFAULT_CHECKPOINT_PATH)
+    parser.add_argument("--val-split", type=Path, default=DEFAULT_VAL_SPLIT)
+    parser.add_argument("--archive-path", type=Path, default=REPO_ROOT / DEFAULT_ARCHIVE_PATH)
+    parser.add_argument("--image-root", type=Path, default=None)
+    parser.add_argument("--image-size", type=int, default=1024)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--aggregation", choices=AGGREGATION_CHOICES, default="mean")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    dataset = SingleImageDataset(
+        index_csv_path=args.val_split,
+        archive_path=args.archive_path,
+        transform=build_eval_transform(image_size=args.image_size, num_channels=3),
+        image_root=args.image_root,
+    )
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+    )
+
+    try:
+        model = MinimalSingleImageCNN(in_channels=3).to(device)
+        state_dict = torch.load(args.checkpoint, map_location=device)
+        model.load_state_dict(state_dict)
+
+        image_prediction_rows = collect_single_image_prediction_rows(
+            model=model,
+            loader=loader,
+            device=device,
+        )
+        evaluation_result = evaluate_prediction_rows(
+            prediction_rows=image_prediction_rows,
+            aggregation=args.aggregation,
+            item_id_field="image_id",
+        )
+        output_paths = write_evaluation_artifacts(
+            output_dir=args.output_dir,
+            image_prediction_rows=evaluation_result["image_prediction_rows"],
+            breast_prediction_rows=evaluation_result["breast_prediction_rows"],
+            metrics=evaluation_result["metrics"],
+        )
+    finally:
+        dataset.close()
+
+    print("Evaluation finished successfully")
+    print(f"- checkpoint: {args.checkpoint}")
+    print(f"- aggregation: {args.aggregation}")
+    print(f"- image predictions: {len(evaluation_result['image_prediction_rows'])}")
+    print(f"- breast predictions: {len(evaluation_result['breast_prediction_rows'])}")
+    print(f"- breast auroc: {format_metric_value(evaluation_result['metrics']['breast_auroc'])}")
+    print(f"- auroc available: {evaluation_result['metrics']['auroc_available']}")
+    print(f"- wrote: {output_paths['image_predictions']}")
+    print(f"- wrote: {output_paths['breast_predictions']}")
+    print(f"- wrote: {output_paths['metrics']}")
+    return 0
+
+
+def format_metric_value(value: float | None) -> str:
+    if value is None:
+        return "None"
+    return f"{value:.4f}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,0 +1,28 @@
+"""Minimal evaluation interface for Stage 1 breast-level aggregation."""
+
+from .aggregation import AGGREGATION_CHOICES, BREAST_LEVEL_PREDICTION_FIELDS, aggregate_prediction_rows
+from .metrics import build_breast_level_metrics, compute_binary_auroc
+from .pipeline import (
+    BREAST_LEVEL_METRICS_FILENAME,
+    BREAST_LEVEL_PREDICTIONS_FILENAME,
+    IMAGE_LEVEL_PREDICTIONS_FILENAME,
+    IMAGE_LEVEL_PREDICTION_FIELDS,
+    collect_single_image_prediction_rows,
+    evaluate_prediction_rows,
+    write_evaluation_artifacts,
+)
+
+__all__ = [
+    "AGGREGATION_CHOICES",
+    "BREAST_LEVEL_PREDICTION_FIELDS",
+    "IMAGE_LEVEL_PREDICTION_FIELDS",
+    "IMAGE_LEVEL_PREDICTIONS_FILENAME",
+    "BREAST_LEVEL_PREDICTIONS_FILENAME",
+    "BREAST_LEVEL_METRICS_FILENAME",
+    "aggregate_prediction_rows",
+    "compute_binary_auroc",
+    "build_breast_level_metrics",
+    "collect_single_image_prediction_rows",
+    "evaluate_prediction_rows",
+    "write_evaluation_artifacts",
+]

--- a/src/eval/aggregation.py
+++ b/src/eval/aggregation.py
@@ -1,0 +1,68 @@
+"""Breast-level aggregation helpers for Stage 1 evaluation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+
+AGGREGATION_CHOICES = ("mean", "max")
+BREAST_LEVEL_PREDICTION_FIELDS = (
+    "breast_id",
+    "target",
+    "prediction",
+    "num_items_aggregated",
+    "item_ids",
+)
+
+
+def aggregate_prediction_rows(
+    prediction_rows: list[dict[str, Any]],
+    aggregation: str = "mean",
+    group_field: str = "breast_id",
+    target_field: str = "target",
+    prediction_field: str = "prediction",
+    item_id_field: str | None = "image_id",
+) -> list[dict[str, Any]]:
+    """Aggregate prediction rows into one breast-level prediction per breast_id."""
+
+    if aggregation not in AGGREGATION_CHOICES:
+        raise ValueError(
+            f"Unsupported aggregation '{aggregation}'. Expected one of: {', '.join(AGGREGATION_CHOICES)}."
+        )
+
+    grouped_predictions: dict[str, list[float]] = defaultdict(list)
+    grouped_targets: dict[str, list[int]] = defaultdict(list)
+    grouped_item_ids: dict[str, list[str]] = defaultdict(list)
+
+    for row in prediction_rows:
+        breast_id = str(row[group_field])
+        grouped_predictions[breast_id].append(float(row[prediction_field]))
+        grouped_targets[breast_id].append(int(row[target_field]))
+        if item_id_field and str(row.get(item_id_field, "")):
+            grouped_item_ids[breast_id].append(str(row[item_id_field]))
+
+    aggregated_rows: list[dict[str, Any]] = []
+    for breast_id in sorted(grouped_predictions):
+        target_values = grouped_targets[breast_id]
+        if len(set(target_values)) != 1:
+            raise ValueError(f"Inconsistent targets found for breast_id '{breast_id}'.")
+
+        prediction_values = grouped_predictions[breast_id]
+        if aggregation == "mean":
+            aggregated_prediction = float(sum(prediction_values) / len(prediction_values))
+        else:
+            aggregated_prediction = float(max(prediction_values))
+
+        unique_item_ids = sorted(set(grouped_item_ids[breast_id]))
+        aggregated_rows.append(
+            {
+                "breast_id": breast_id,
+                "target": target_values[0],
+                "prediction": aggregated_prediction,
+                "num_items_aggregated": len(prediction_values),
+                "item_ids": "|".join(unique_item_ids),
+            }
+        )
+
+    return aggregated_rows

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,0 +1,39 @@
+"""Metrics helpers for Stage 1 evaluation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Sequence
+
+from sklearn.metrics import roc_auc_score
+
+
+def compute_binary_auroc(targets: Sequence[int], predictions: Sequence[float]) -> float | None:
+    """Compute AUROC with safe single-class fallback."""
+
+    if len(set(int(target) for target in targets)) < 2:
+        return None
+    return float(roc_auc_score(list(targets), list(predictions)))
+
+
+def build_breast_level_metrics(
+    breast_prediction_rows: list[dict[str, Any]],
+    aggregation: str,
+) -> dict[str, Any]:
+    """Build the minimal breast-level metrics summary."""
+
+    targets = [int(row["target"]) for row in breast_prediction_rows]
+    predictions = [float(row["prediction"]) for row in breast_prediction_rows]
+    breast_auroc = compute_binary_auroc(targets, predictions)
+
+    return {
+        "aggregation": aggregation,
+        "num_breasts": len(breast_prediction_rows),
+        "label_counts": {
+            str(label): count
+            for label, count in sorted(Counter(targets).items())
+        },
+        "breast_auroc": breast_auroc,
+        "auroc_available": breast_auroc is not None,
+        "auroc_reason": "" if breast_auroc is not None else "Only one target class present in breast-level predictions.",
+    }

--- a/src/eval/pipeline.py
+++ b/src/eval/pipeline.py
@@ -1,0 +1,132 @@
+"""Prediction collection and artifact writing helpers for Stage 1 evaluation."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from .aggregation import BREAST_LEVEL_PREDICTION_FIELDS, aggregate_prediction_rows
+from .metrics import build_breast_level_metrics
+
+
+IMAGE_LEVEL_PREDICTION_FIELDS = (
+    "image_id",
+    "breast_id",
+    "target",
+    "prediction",
+    "image_path",
+    "view",
+)
+IMAGE_LEVEL_PREDICTIONS_FILENAME = "image_level_predictions.csv"
+BREAST_LEVEL_PREDICTIONS_FILENAME = "breast_level_predictions.csv"
+BREAST_LEVEL_METRICS_FILENAME = "breast_level_metrics.json"
+
+
+def collect_single_image_prediction_rows(
+    model: nn.Module,
+    loader: DataLoader[dict[str, Any]],
+    device: torch.device,
+) -> list[dict[str, Any]]:
+    """Collect image-level prediction rows from a single-image validation loader."""
+
+    model.eval()
+    prediction_rows: list[dict[str, Any]] = []
+
+    with torch.no_grad():
+        for batch in loader:
+            images = batch["image"].to(device)
+            logits = model(images)
+            probabilities = torch.sigmoid(logits).cpu().tolist()
+            targets = batch["target"].cpu().tolist()
+
+            for index, probability in enumerate(probabilities):
+                prediction_rows.append(
+                    {
+                        "image_id": str(batch["image_id"][index]),
+                        "breast_id": str(batch["breast_id"][index]),
+                        "target": int(targets[index]),
+                        "prediction": float(probability),
+                        "image_path": str(batch["image_path"][index]),
+                        "view": str(batch["view"][index]),
+                    }
+                )
+
+    return prediction_rows
+
+
+def evaluate_prediction_rows(
+    prediction_rows: list[dict[str, Any]],
+    aggregation: str = "mean",
+    item_id_field: str | None = "image_id",
+) -> dict[str, Any]:
+    """Aggregate prediction rows and build the minimal breast-level metrics payload."""
+
+    breast_prediction_rows = aggregate_prediction_rows(
+        prediction_rows=prediction_rows,
+        aggregation=aggregation,
+        item_id_field=item_id_field,
+    )
+    metrics = build_breast_level_metrics(
+        breast_prediction_rows=breast_prediction_rows,
+        aggregation=aggregation,
+    )
+    return {
+        "image_prediction_rows": prediction_rows,
+        "breast_prediction_rows": breast_prediction_rows,
+        "metrics": metrics,
+    }
+
+
+def write_evaluation_artifacts(
+    output_dir: str | Path,
+    breast_prediction_rows: list[dict[str, Any]],
+    metrics: dict[str, Any],
+    image_prediction_rows: list[dict[str, Any]] | None = None,
+) -> dict[str, Path]:
+    """Write evaluation artifacts to disk."""
+
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    image_predictions_path = output_root / IMAGE_LEVEL_PREDICTIONS_FILENAME
+    breast_predictions_path = output_root / BREAST_LEVEL_PREDICTIONS_FILENAME
+    metrics_path = output_root / BREAST_LEVEL_METRICS_FILENAME
+
+    if image_prediction_rows is not None:
+        _write_csv_rows(
+            path=image_predictions_path,
+            fieldnames=IMAGE_LEVEL_PREDICTION_FIELDS,
+            rows=image_prediction_rows,
+        )
+    _write_csv_rows(
+        path=breast_predictions_path,
+        fieldnames=BREAST_LEVEL_PREDICTION_FIELDS,
+        rows=breast_prediction_rows,
+    )
+    with metrics_path.open("w", encoding="utf-8") as handle:
+        json.dump(metrics, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+    return {
+        "image_predictions": image_predictions_path,
+        "breast_predictions": breast_predictions_path,
+        "metrics": metrics_path,
+    }
+
+
+def _write_csv_rows(
+    path: Path,
+    fieldnames: tuple[str, ...],
+    rows: list[dict[str, Any]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fieldnames})

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import csv
+import json
+import shutil
+import unittest
+import uuid
+from pathlib import Path
+
+from src.eval import aggregate_prediction_rows, compute_binary_auroc, evaluate_prediction_rows, write_evaluation_artifacts
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_TMP_ROOT = REPO_ROOT / "outputs" / "test_tmp"
+
+
+class EvaluationTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        TEST_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        self.root = TEST_TMP_ROOT / uuid.uuid4().hex
+        self.root.mkdir(parents=True, exist_ok=False)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_mean_aggregation_is_correct(self) -> None:
+        rows = [
+            self.make_prediction_row("A", "A_CC", 1, 0.2),
+            self.make_prediction_row("A", "A_MLO", 1, 0.8),
+        ]
+
+        aggregated = aggregate_prediction_rows(rows, aggregation="mean")
+
+        self.assertEqual(len(aggregated), 1)
+        self.assertEqual(aggregated[0]["breast_id"], "A")
+        self.assertEqual(aggregated[0]["target"], 1)
+        self.assertAlmostEqual(aggregated[0]["prediction"], 0.5)
+        self.assertEqual(aggregated[0]["num_items_aggregated"], 2)
+
+    def test_max_aggregation_is_correct(self) -> None:
+        rows = [
+            self.make_prediction_row("A", "A_CC", 1, 0.2),
+            self.make_prediction_row("A", "A_MLO", 1, 0.8),
+        ]
+
+        aggregated = aggregate_prediction_rows(rows, aggregation="max")
+
+        self.assertEqual(len(aggregated), 1)
+        self.assertAlmostEqual(aggregated[0]["prediction"], 0.8)
+
+    def test_inconsistent_targets_raise(self) -> None:
+        rows = [
+            self.make_prediction_row("A", "A_CC", 1, 0.2),
+            self.make_prediction_row("A", "A_MLO", 0, 0.8),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "Inconsistent targets"):
+            aggregate_prediction_rows(rows, aggregation="mean")
+
+    def test_single_class_auroc_returns_none(self) -> None:
+        auroc = compute_binary_auroc(targets=[0, 0, 0], predictions=[0.1, 0.2, 0.3])
+        self.assertIsNone(auroc)
+
+    def test_evaluation_artifacts_are_written(self) -> None:
+        image_rows = [
+            self.make_prediction_row("A", "A_CC", 1, 0.2),
+            self.make_prediction_row("A", "A_MLO", 1, 0.8),
+            self.make_prediction_row("B", "B_CC", 0, 0.1),
+            self.make_prediction_row("B", "B_MLO", 0, 0.4),
+        ]
+
+        evaluation_result = evaluate_prediction_rows(image_rows, aggregation="mean")
+        output_paths = write_evaluation_artifacts(
+            output_dir=self.root / "eval_output",
+            image_prediction_rows=evaluation_result["image_prediction_rows"],
+            breast_prediction_rows=evaluation_result["breast_prediction_rows"],
+            metrics=evaluation_result["metrics"],
+        )
+
+        self.assertTrue(output_paths["image_predictions"].exists())
+        self.assertTrue(output_paths["breast_predictions"].exists())
+        self.assertTrue(output_paths["metrics"].exists())
+
+        breast_rows = self.read_csv(output_paths["breast_predictions"])
+        metrics = json.loads(output_paths["metrics"].read_text(encoding="utf-8"))
+
+        self.assertEqual(len(breast_rows), 2)
+        self.assertEqual({row["breast_id"] for row in breast_rows}, {"A", "B"})
+        self.assertTrue(metrics["auroc_available"])
+        self.assertIsNotNone(metrics["breast_auroc"])
+
+    def make_prediction_row(self, breast_id: str, image_id: str, target: int, prediction: float) -> dict[str, object]:
+        view = "CC" if image_id.endswith("CC") else "MLO"
+        return {
+            "image_id": image_id,
+            "breast_id": breast_id,
+            "target": target,
+            "prediction": prediction,
+            "image_path": f"train_img/{breast_id}/{image_id}.jpg",
+            "view": view,
+        }
+
+    def read_csv(self, path: Path) -> list[dict[str, str]]:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            return list(csv.DictReader(handle))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
what:
- implement Stage 1 Issue 1.5 minimal evaluation modules under src/eval for prediction aggregation and AUROC calculation
- add a runnable evaluation script that collects validation predictions, aggregates them by breast_id with mean or max, and writes evaluation artifacts
- add focused tests covering aggregation correctness, target consistency checks, single-class AUROC fallback, and artifact generation

why:
- align M1 result reporting with the project’s breast-level malignant probability task definition
- provide a small reusable evaluation path that can be carried forward into the Stage 2 baseline without introducing a heavy evaluator framework