### PR TITLE
feat(scripts | stage1-6): add end-to-end stage1 smoke test and sanity report

### DIFF
--- a/docs/ai/feedback/stage1/feedback_stage1-6.md
+++ b/docs/ai/feedback/stage1/feedback_stage1-6.md
@@ -1,0 +1,117 @@
+1. 修改了哪些文件
+
+修改了 [run_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_stage1_smoke.py) 和 [test_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_stage1_smoke.py)。
+
+本次实际生成的 smoke 产物在 [outputs/m1_smoke](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke)：
+[stage1_smoke_report.md](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/stage1_smoke_report.md)、[metrics_summary.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train/metrics_summary.json)、[best_model.pt](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train/best_model.pt)、[image_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/image_level_predictions.csv)、[breast_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/breast_level_predictions.csv)、[breast_level_metrics.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/breast_level_metrics.json)。
+
+2. 每个文件的作用
+
+[scripts/run_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_stage1_smoke.py) 是 Issue 1.6 的最小端到端 smoke 脚本。它复用已有 `train_baseline.py` 和 `run_eval.py`，顺序跑训练与评估，保存 stdout/stderr 日志，读取产物并生成一份 sanity report。
+
+[tests/test_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_stage1_smoke.py) 是最小集成测试。它用合成 split 和 zip 图像调起 smoke 脚本，验证 report、train summary、eval metrics 和 prediction artifact 都能生成。
+
+3. smoke test 采用了什么最小配置
+
+这次实际 smoke 配置是：
+
+- train split: [primary_single_image_split_train.csv](d:/MyProject/Breast-Cancer-Detection-Model/data/processed/splits/primary_single_image_split_train.csv)
+- val split: [primary_single_image_split_val.csv](d:/MyProject/Breast-Cancer-Detection-Model/data/processed/splits/primary_single_image_split_val.csv)
+- split context: [primary_split_summary.json](d:/MyProject/Breast-Cancer-Detection-Model/data/processed/splits/primary_split_summary.json)，其中 `val_fold=0`
+- epochs: `1`
+- batch size: `8`
+- image size: `512`
+- device: `cpu`
+- selection metric: `auto`
+- aggregation: `mean`
+- output dir: [outputs/m1_smoke](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke)
+
+4. 端到端串起了哪些已有模块
+
+这次没有重发明流程，只做了薄胶水层：
+
+- 复用 Issue 1.3 的 single-image split artifacts
+- 复用 Issue 1.2 的 `SingleImageDataset` 和 transforms
+- 复用 Issue 1.4 / 1.4.x 的 [train_baseline.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/train_baseline.py) 与 `trainer.py`
+- 复用 Issue 1.5 的 [run_eval.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_eval.py) 和 `src/eval/`
+- 新脚本只负责串联、记录日志、汇总关键路径、写 sanity report
+
+5. 输出了哪些日志/产物，保存到哪里
+
+都保存在 [outputs/m1_smoke](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke)：
+
+- 训练日志: [train_stdout.log](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train_stdout.log), [train_stderr.log](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train_stderr.log)
+- 评估日志: [eval_stdout.log](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval_stdout.log), [eval_stderr.log](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval_stderr.log)
+- 训练产物: [config.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train/config.json), [metrics_summary.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train/metrics_summary.json), [best_model.pt](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/train/best_model.pt)
+- 评估产物: [image_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/image_level_predictions.csv), [breast_level_predictions.csv](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/breast_level_predictions.csv), [breast_level_metrics.json](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/eval/breast_level_metrics.json)
+- sanity report: [stage1_smoke_report.md](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/stage1_smoke_report.md)
+
+6. sanity report 包含哪些结论
+
+报告在 [stage1_smoke_report.md](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/stage1_smoke_report.md)，核心结论是：
+
+- 标签对齐看起来正常：val split 的 breast-level 标签分布 `{'0': 98, '1': 32}` 与评估输出一致
+- loss 能正常计算且保持 finite，没有 NaN / inf
+- 预测有明显塌缩风险：breast-level prediction `min=0.5655`, `max=0.5922`, `std=0.0049`
+- breast-level AUROC 计算流程跑通，实际得到 `0.4225`
+- 这次结果更像“闭环已成立”的 sanity run，不像“已有合理效果”的 baseline
+
+报告里明确写了：
+- 当前闭环成立
+- 当前主要限制是近似常数输出
+- 进入 M2 前的主要风险是带着结构正确但很弱的单图 baseline 继续推进
+
+7. 给出一次最小运行方式
+
+```bash
+python scripts/run_stage1_smoke.py
+```
+
+测试模式最小验证：
+
+```bash
+python -m unittest tests.test_stage1_smoke
+```
+
+8. 给出一段实际运行输出示例
+
+```text
+Stage 1 smoke test finished successfully
+- output dir: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_smoke
+- report: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_smoke\stage1_smoke_report.md
+- train metrics: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_smoke\train\metrics_summary.json
+- eval metrics: D:\MyProject\Breast-Cancer-Detection-Model\outputs\m1_smoke\eval\breast_level_metrics.json
+- breast auroc: 0.4225
+- collapse suspected: True
+```
+
+9. 补了哪些测试或验证步骤
+
+新增了 [tests/test_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/tests/test_stage1_smoke.py)，覆盖：
+
+- smoke 脚本能在超小配置下启动并完成 train + eval
+- `stage1_smoke_report.md` 成功生成
+- train/eval 关键 artifact 成功生成
+- report 中能看到关键产物路径和 sanity 结论字段
+
+实际已验证：
+
+```bash
+python -m unittest tests.test_stage1_smoke
+python -m unittest tests.test_index_builder tests.test_datasets tests.test_splits tests.test_split_fold_assignment tests.test_training_smoke tests.test_eval tests.test_stage1_smoke
+python scripts/run_stage1_smoke.py
+```
+
+10. 明确说明这次实现如何对应 issue_stage1.md 中 Issue 1.6 的 Goal / Scope / Deliverables / Acceptance Criteria
+
+对应关系是直接对齐的：
+
+- Goal：新增 [run_stage1_smoke.py](d:/MyProject/Breast-Cancer-Detection-Model/scripts/run_stage1_smoke.py)，并实际跑出 [stage1_smoke_report.md](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke/stage1_smoke_report.md)
+- Scope：选了一个 CPU 友好的最小配置，串起数据读取、训练、验证、breast-level 聚合评估，保存日志与结果，并记录异常观察
+- Deliverables：已有 smoke 脚本、sanity report、日志、metrics、checkpoint、prediction artifact
+- Acceptance Criteria：闭环已完整跑通；breast-level AUROC 已实际生成；报告里给了明确 sanity 判断，而不是只写“跑过了”；也明确指出了当前的基础问题是输出接近常数、效果不可信
+
+路径适配说明：
+- 本次权威 issue 文档实际使用的是 [docs/gitflow/issue/issue_stage1.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/gitflow/issue/issue_stage1.md)
+- sanity report 放在 `outputs/m1_smoke/` 而不是 `docs/reports/`，这是有意保持它作为一次运行产物，和现有 `outputs/m1_baseline/` 风格一致
+- 本次没有重构 trainer 或 eval 框架，只加了最小胶水层，未越界到 Issue 1.7 的文档整理工作

--- a/docs/ai/prompt/stage1/prpmpt_stage1-6.md
+++ b/docs/ai/prompt/stage1/prpmpt_stage1-6.md
@@ -1,0 +1,176 @@
+你现在继续为乳腺癌检测课程项目实现 Milestone 1 的 Issue 1.6。
+
+当前唯一权威的 issue 定义来源是：
+- docs/gitflow/issue/issue_stage1.md
+请先阅读并严格遵守其中对 Issue 1.6 的定义，不要自行改写 issue 目标。
+
+你还必须结合以下现有实现：
+1. docs/plan/minimal_system_design.md
+2. docs/gitflow/issue/issue_stage1.md 中 Issue 1.6 的原始要求
+3. 已完成的 Issue 1.1–1.5 相关代码与脚本
+4. data/processed/metadata/ 下的 index artifacts
+5. data/processed/splits/ 下的 split / fold artifacts
+6. outputs/m1_baseline/ 下当前训练产物
+7. outputs/m1_baseline/eval/ 下当前评估产物
+
+如果仓库实际路径与文档不一致，不要臆造，基于仓库现状做最小合理适配，并在最终汇报中明确指出差异。
+
+================================
+一、严格按原 issue 定义执行
+================================
+
+Issue 1.6 的原始定义是：
+
+Title:
+Run One End-to-End Smoke Test and Record Sanity Findings
+
+Goal:
+基于当前最小管线完成一次端到端 smoke test，并形成可复查的 sanity 记录。
+
+Scope:
+- 选定一个最小可运行配置
+- 跑通至少 1 fold 或一个小规模 train/val 实验
+- 保存基本日志与结果
+- 记录基础异常与观察结论
+
+Deliverables:
+- smoke test 运行脚本
+- 一份简短的 sanity report（md）
+- 运行日志、指标与必要输出文件路径
+
+Acceptance Criteria:
+- 能完整跑通数据读取、训练、验证、评估闭环
+- 生成 breast-level AUROC 或至少完成该指标计算流程
+- 有明确的 sanity 结论，而不是只说“跑过了”
+- 能指出是否存在基础问题（标签错、loss 异常、输出塌缩、明显过拟合等）
+
+你必须以这些要求为准，不要把本 issue 扩展成正式 benchmark 或复杂实验系统。
+
+================================
+二、本次允许做的内容
+================================
+
+1. 新增一个端到端 smoke test 运行脚本，串起：
+   - split 读取
+   - train baseline
+   - eval pipeline
+2. 选择一个最小可运行配置（例如 1 epoch、小 batch、CPU 友好参数）
+3. 保存训练日志、评估产物和必要路径信息
+4. 写一份简短但有判断力的 sanity report（markdown）
+5. 如有必要，可补一个非常轻量的工具函数/脚本包装，但不要重构 trainer 或 eval 框架
+6. 补充最小测试，验证 smoke 脚本至少能调起闭环中的关键步骤
+
+================================
+三、本次不允许做的内容
+================================
+
+1. 不做正式多折实验框架
+2. 不做超参数搜索
+3. 不做模型结构升级
+4. 不进入 paired 双分支训练
+5. 不做大规模文档整理（那是 Issue 1.7）
+6. 不把本 issue 变成“为了好看指标而调参”
+
+================================
+四、实现要求
+================================
+
+请优先做一个最小、清晰、可复查的 smoke 方案。
+
+建议但不强制的实现方向：
+- scripts/run_stage1_smoke.py
+- outputs/m1_smoke/ 或 outputs/m1_baseline/smoke/
+- docs/reports/stage1_smoke_report.md 或等价路径
+
+这个脚本应尽量串起已有最小闭环，而不是重新发明一套流程。
+优先复用已有：
+- train_baseline.py
+- run_eval.py
+- 现有 split artifacts
+- 现有 output 结构
+
+如需通过 subprocess 调用已有脚本可以接受；
+如你认为直接调用 Python 接口更稳，也可以，但不要为此重构已有代码。
+
+================================
+五、sanity report 的最低要求
+================================
+
+请写一份简短 markdown 报告，至少包含：
+
+1. 本次 smoke test 使用的最小配置
+   - 数据 split
+   - epoch
+   - batch size
+   - image size
+   - device
+   - checkpoint / output dir
+
+2. 跑通了哪些环节
+   - 数据读取
+   - 训练
+   - 验证
+   - breast-level 聚合评估
+
+3. 关键产物路径
+   - config / summary / checkpoint
+   - image-level predictions
+   - breast-level predictions
+   - breast-level metrics
+
+4. 关键观察
+   至少回答：
+   - 标签是否看起来对齐
+   - loss 是否能正常计算、是否有明显异常
+   - 输出是否有塌缩迹象（例如几乎常数）
+   - 评估脚本是否成功产出 breast-level AUROC
+   - 当前结果更像“能跑通”还是“已有合理效果”
+
+5. 明确 sanity 结论
+   不能只写“已成功运行”，必须给出判断：
+   - 当前闭环是否成立
+   - 当前最主要的限制是什么
+   - 进入 M2 前最值得注意的风险是什么
+
+================================
+六、最小验收标准
+================================
+
+你的实现必须满足：
+
+1. 能完整跑通数据读取、训练、验证、评估闭环
+2. 至少产出一次 breast-level AUROC 或完成该计算流程
+3. 有单独的 smoke test 运行脚本
+4. 有一份简短但有判断力的 sanity report
+5. 报告里能指出至少一种当前存在或潜在的基础问题/限制
+6. 不越界到 Issue 1.7 的大规模文档整理
+
+================================
+七、测试要求
+================================
+
+请补充最小测试或验证方式，至少覆盖其一：
+1. smoke 脚本在测试模式/超小配置下可启动并完成关键阶段
+2. smoke 脚本正确汇总并输出关键产物路径
+3. sanity report 成功生成
+
+测试保持最小即可，不要为了测试重写工程结构。
+
+================================
+八、最终汇报格式
+================================
+
+请按以下格式返回：
+
+1. 修改了哪些文件
+2. 每个文件的作用
+3. smoke test 采用了什么最小配置
+4. 端到端串起了哪些已有模块
+5. 输出了哪些日志/产物，保存到哪里
+6. sanity report 包含哪些结论
+7. 给出一次最小运行方式
+8. 给出一段实际运行输出示例
+9. 补了哪些测试或验证步骤
+10. 明确说明这次实现如何对应 issue_stage1.md 中 Issue 1.6 的 Goal / Scope / Deliverables / Acceptance Criteria
+
+如果你发现现有脚本之间的接口不够顺滑，请做最小合理胶水层，不要借机重构整个训练/评估系统。当前任务是完成 M1 的端到端 smoke 与 sanity 记录。

--- a/scripts/run_stage1_smoke.py
+++ b/scripts/run_stage1_smoke.py
@@ -1,0 +1,371 @@
+"""Run one Stage 1 end-to-end smoke test and record sanity findings."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TRAIN_SPLIT = REPO_ROOT / "data" / "processed" / "splits" / "primary_single_image_split_train.csv"
+DEFAULT_VAL_SPLIT = REPO_ROOT / "data" / "processed" / "splits" / "primary_single_image_split_val.csv"
+DEFAULT_ARCHIVE_PATH = REPO_ROOT / "data" / "raw" / "primary" / "train_img.zip"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "m1_smoke"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--train-split", type=Path, default=DEFAULT_TRAIN_SPLIT)
+    parser.add_argument("--val-split", type=Path, default=DEFAULT_VAL_SPLIT)
+    parser.add_argument("--archive-path", type=Path, default=DEFAULT_ARCHIVE_PATH)
+    parser.add_argument("--image-root", type=Path, default=None)
+    parser.add_argument("--image-size", type=int, default=512)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--selection-metric", type=str, default="auto")
+    parser.add_argument("--aggregation", type=str, default="mean")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = args.output_dir
+    train_output_dir = output_dir / "train"
+    eval_output_dir = output_dir / "eval"
+    report_path = output_dir / "stage1_smoke_report.md"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    train_command = build_train_command(args, train_output_dir)
+    train_result = run_and_log(
+        command=train_command,
+        stdout_path=output_dir / "train_stdout.log",
+        stderr_path=output_dir / "train_stderr.log",
+    )
+    if train_result.returncode != 0:
+        print("Smoke test failed during training.", file=sys.stderr)
+        print(f"- train stdout: {output_dir / 'train_stdout.log'}", file=sys.stderr)
+        print(f"- train stderr: {output_dir / 'train_stderr.log'}", file=sys.stderr)
+        return train_result.returncode
+
+    eval_command = build_eval_command(args, train_output_dir / "best_model.pt", eval_output_dir)
+    eval_result = run_and_log(
+        command=eval_command,
+        stdout_path=output_dir / "eval_stdout.log",
+        stderr_path=output_dir / "eval_stderr.log",
+    )
+    if eval_result.returncode != 0:
+        print("Smoke test failed during evaluation.", file=sys.stderr)
+        print(f"- eval stdout: {output_dir / 'eval_stdout.log'}", file=sys.stderr)
+        print(f"- eval stderr: {output_dir / 'eval_stderr.log'}", file=sys.stderr)
+        return eval_result.returncode
+
+    train_config = read_json(train_output_dir / "config.json")
+    train_metrics = read_json(train_output_dir / "metrics_summary.json")
+    eval_metrics = read_json(eval_output_dir / "breast_level_metrics.json")
+    image_prediction_rows = read_csv_rows(eval_output_dir / "image_level_predictions.csv")
+    breast_prediction_rows = read_csv_rows(eval_output_dir / "breast_level_predictions.csv")
+
+    split_context = resolve_split_context(args.train_split, args.val_split)
+    val_image_label_counts = count_split_image_labels(args.val_split)
+    val_breast_label_counts = count_split_breast_labels(args.val_split)
+    image_prediction_stats = summarize_predictions(image_prediction_rows)
+    breast_prediction_stats = summarize_predictions(breast_prediction_rows)
+    report = build_report(
+        args=args,
+        train_output_dir=train_output_dir,
+        eval_output_dir=eval_output_dir,
+        train_config=train_config,
+        train_metrics=train_metrics,
+        eval_metrics=eval_metrics,
+        val_image_label_counts=val_image_label_counts,
+        val_breast_label_counts=val_breast_label_counts,
+        image_prediction_stats=image_prediction_stats,
+        breast_prediction_stats=breast_prediction_stats,
+        split_context=split_context,
+    )
+    report_path.write_text(report, encoding="utf-8")
+
+    print("Stage 1 smoke test finished successfully")
+    print(f"- output dir: {output_dir}")
+    print(f"- report: {report_path}")
+    print(f"- train metrics: {train_output_dir / 'metrics_summary.json'}")
+    print(f"- eval metrics: {eval_output_dir / 'breast_level_metrics.json'}")
+    print(f"- breast auroc: {format_metric_value(eval_metrics['breast_auroc'])}")
+    print(f"- collapse suspected: {breast_prediction_stats['collapse_suspected']}")
+    return 0
+
+
+def build_train_command(args: argparse.Namespace, train_output_dir: Path) -> list[str]:
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "train_baseline.py"),
+        "--train-split",
+        str(args.train_split),
+        "--val-split",
+        str(args.val_split),
+        "--archive-path",
+        str(args.archive_path),
+        "--image-size",
+        str(args.image_size),
+        "--batch-size",
+        str(args.batch_size),
+        "--epochs",
+        str(args.epochs),
+        "--lr",
+        str(args.lr),
+        "--seed",
+        str(args.seed),
+        "--num-workers",
+        str(args.num_workers),
+        "--selection-metric",
+        str(args.selection_metric),
+        "--output-dir",
+        str(train_output_dir),
+    ]
+    if args.image_root is not None:
+        command.extend(["--image-root", str(args.image_root)])
+    return command
+
+
+def build_eval_command(args: argparse.Namespace, checkpoint_path: Path, eval_output_dir: Path) -> list[str]:
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "run_eval.py"),
+        "--checkpoint",
+        str(checkpoint_path),
+        "--val-split",
+        str(args.val_split),
+        "--archive-path",
+        str(args.archive_path),
+        "--image-size",
+        str(args.image_size),
+        "--batch-size",
+        str(args.batch_size),
+        "--num-workers",
+        str(args.num_workers),
+        "--aggregation",
+        str(args.aggregation),
+        "--output-dir",
+        str(eval_output_dir),
+    ]
+    if args.image_root is not None:
+        command.extend(["--image-root", str(args.image_root)])
+    return command
+
+
+def run_and_log(command: list[str], stdout_path: Path, stderr_path: Path) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    stdout_path.write_text(completed.stdout, encoding="utf-8")
+    stderr_path.write_text(completed.stderr, encoding="utf-8")
+    return completed
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def count_split_image_labels(path: Path) -> dict[str, int]:
+    rows = read_csv_rows(path)
+    return {
+        str(label): count
+        for label, count in sorted(Counter(int(row["is_malignant"]) for row in rows).items())
+    }
+
+
+def count_split_breast_labels(path: Path) -> dict[str, int]:
+    rows = read_csv_rows(path)
+    grouped_targets: dict[str, int] = {}
+    for row in rows:
+        breast_id = str(row["breast_id"])
+        target = int(row["is_malignant"])
+        if breast_id in grouped_targets and grouped_targets[breast_id] != target:
+            raise ValueError(f"Inconsistent targets found in split CSV for breast_id '{breast_id}'.")
+        grouped_targets[breast_id] = target
+    return {
+        str(label): count
+        for label, count in sorted(Counter(grouped_targets.values()).items())
+    }
+
+
+def summarize_predictions(rows: list[dict[str, str]]) -> dict[str, Any]:
+    predictions = [float(row["prediction"]) for row in rows]
+    if not predictions:
+        return {
+            "count": 0,
+            "min": None,
+            "max": None,
+            "mean": None,
+            "std": None,
+            "range": None,
+            "collapse_suspected": True,
+        }
+
+    prediction_min = min(predictions)
+    prediction_max = max(predictions)
+    prediction_std = statistics.pstdev(predictions) if len(predictions) > 1 else 0.0
+    prediction_range = prediction_max - prediction_min
+    collapse_suspected = prediction_std < 0.02 or prediction_range < 0.05
+    return {
+        "count": len(predictions),
+        "min": prediction_min,
+        "max": prediction_max,
+        "mean": float(sum(predictions) / len(predictions)),
+        "std": prediction_std,
+        "range": prediction_range,
+        "collapse_suspected": collapse_suspected,
+    }
+
+
+def resolve_split_context(train_split: Path, val_split: Path) -> dict[str, Any]:
+    split_summary_path = val_split.parent / "primary_split_summary.json"
+    if not split_summary_path.exists():
+        return {
+            "summary_path": None,
+            "val_fold": None,
+            "train_folds": [],
+            "paired_val_label_counts": None,
+            "single_val_label_counts": None,
+        }
+
+    split_summary = read_json(split_summary_path)
+    fold_assignment = split_summary.get("fold_assignment", {})
+    paired = split_summary.get("paired", {})
+    single = split_summary.get("single", {})
+    return {
+        "summary_path": str(split_summary_path),
+        "val_fold": fold_assignment.get("val_fold"),
+        "train_folds": fold_assignment.get("train_folds", []),
+        "paired_val_label_counts": paired.get("val", {}).get("label_counts"),
+        "single_val_label_counts": single.get("val", {}).get("label_counts"),
+    }
+
+
+def build_report(
+    args: argparse.Namespace,
+    train_output_dir: Path,
+    eval_output_dir: Path,
+    train_config: dict[str, Any],
+    train_metrics: dict[str, Any],
+    eval_metrics: dict[str, Any],
+    val_image_label_counts: dict[str, int],
+    val_breast_label_counts: dict[str, int],
+    image_prediction_stats: dict[str, Any],
+    breast_prediction_stats: dict[str, Any],
+    split_context: dict[str, Any],
+) -> str:
+    best_metrics = train_metrics["best_metrics"]
+    label_alignment_ok = val_breast_label_counts == eval_metrics["label_counts"]
+    finite_losses = all(
+        value == value and value not in (float("inf"), float("-inf"))
+        for value in [best_metrics["train_loss"], best_metrics["val_loss"]]
+    )
+    loss_observation = (
+        "Loss computed successfully and remained finite."
+        if finite_losses
+        else "Loss shows NaN/inf or another numerical issue."
+    )
+    label_observation = (
+        "Breast-level label counts from the validation split match the evaluation output, so labels look structurally aligned."
+        if label_alignment_ok
+        else "Breast-level label counts from the validation split do not match the evaluation output; labels need inspection."
+    )
+    collapse_observation = (
+        "Breast-level predictions are tightly clustered, so there is a clear near-constant output / collapse risk."
+        if breast_prediction_stats["collapse_suspected"]
+        else "Prediction spread is not collapsed by the current heuristic."
+    )
+    eval_observation = (
+        f"Breast-level AUROC was computed successfully: {format_metric_value(eval_metrics['breast_auroc'])}."
+        if eval_metrics["auroc_available"]
+        else f"Breast-level AUROC was not available: {eval_metrics['auroc_reason']}"
+    )
+    overall_observation = "This run should be treated as a runnable pipeline sanity check, not as evidence of a strong baseline."
+    conclusion = "The end-to-end M1 loop is established: data loading, training, validation, and breast-level evaluation all completed successfully."
+    main_limitation = "The current baseline still shows near-constant breast-level predictions, so model quality is not yet reliable."
+    next_risk = "The main risk before M2 is carrying a structurally correct but weak single-image baseline forward without addressing output collapse and the gap to the breast-level main task."
+
+    return f"""# Stage 1 Smoke Report
+
+## Minimal Configuration
+- Train split: `{args.train_split}`
+- Val split: `{args.val_split}`
+- Split summary: `{split_context['summary_path']}`
+- Val fold: `{split_context['val_fold']}`
+- Train folds: `{split_context['train_folds']}`
+- Epochs: `{args.epochs}`
+- Batch size: `{args.batch_size}`
+- Image size: `{args.image_size}`
+- Device: `{train_config['device']}`
+- Selection metric: `{train_config['selection_metric']}`
+- Aggregation: `{args.aggregation}`
+- Train output dir: `{train_output_dir}`
+- Eval output dir: `{eval_output_dir}`
+- Checkpoint: `{train_output_dir / 'best_model.pt'}`
+
+## Pipeline Coverage
+- Data loading: passed
+- Training: passed
+- Validation: passed
+- Breast-level aggregation evaluation: passed
+
+## Key Artifact Paths
+- Train config: `{train_output_dir / 'config.json'}`
+- Train metrics summary: `{train_output_dir / 'metrics_summary.json'}`
+- Best checkpoint: `{train_output_dir / 'best_model.pt'}`
+- Image-level predictions: `{eval_output_dir / 'image_level_predictions.csv'}`
+- Breast-level predictions: `{eval_output_dir / 'breast_level_predictions.csv'}`
+- Breast-level metrics: `{eval_output_dir / 'breast_level_metrics.json'}`
+- Train stdout log: `{args.output_dir / 'train_stdout.log'}`
+- Train stderr log: `{args.output_dir / 'train_stderr.log'}`
+- Eval stdout log: `{args.output_dir / 'eval_stdout.log'}`
+- Eval stderr log: `{args.output_dir / 'eval_stderr.log'}`
+
+## Key Observations
+- Validation split image labels: `{val_image_label_counts}`
+- Validation split breast labels: `{val_breast_label_counts}`
+- Evaluation breast labels: `{eval_metrics['label_counts']}`
+- Label alignment: {label_observation}
+- Loss behavior: {loss_observation}
+- Image prediction spread: count=`{image_prediction_stats['count']}`, min=`{format_metric_value(image_prediction_stats['min'])}`, max=`{format_metric_value(image_prediction_stats['max'])}`, std=`{format_metric_value(image_prediction_stats['std'])}`
+- Breast prediction spread: count=`{breast_prediction_stats['count']}`, min=`{format_metric_value(breast_prediction_stats['min'])}`, max=`{format_metric_value(breast_prediction_stats['max'])}`, std=`{format_metric_value(breast_prediction_stats['std'])}`
+- Output collapse check: {collapse_observation}
+- Evaluation result: {eval_observation}
+- Overall reading: {overall_observation}
+
+## Sanity Conclusion
+- Current loop status: {conclusion}
+- Main limitation: {main_limitation}
+- Main M2 risk: {next_risk}
+"""
+
+
+def format_metric_value(value: float | None) -> str:
+    if value is None:
+        return "None"
+    return f"{value:.4f}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stage1_smoke.py
+++ b/tests/test_stage1_smoke.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import csv
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+import uuid
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+import numpy as np
+from PIL import Image
+
+from src.data import SINGLE_IMAGE_FIELDS
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_TMP_ROOT = REPO_ROOT / "outputs" / "test_tmp"
+
+
+class Stage1SmokeScriptTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        TEST_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        self.root = TEST_TMP_ROOT / uuid.uuid4().hex
+        self.root.mkdir(parents=True, exist_ok=False)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_run_stage1_smoke_script_generates_report_and_key_artifacts(self) -> None:
+        split_dir = self.root / "splits"
+        split_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = self.root / "train_img.zip"
+        train_split_path = split_dir / "primary_single_image_split_train.csv"
+        val_split_path = split_dir / "primary_single_image_split_val.csv"
+        output_dir = self.root / "smoke_output"
+
+        train_rows = self.build_rows([("A_L", 0), ("B_R", 1), ("C_L", 0), ("D_R", 1)])
+        val_rows = self.build_rows([("E_L", 0), ("F_R", 1)])
+
+        self.write_archive(archive_path, train_rows + val_rows)
+        self.write_csv(train_split_path, train_rows)
+        self.write_csv(val_split_path, val_rows)
+        self.write_split_summary(split_dir)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "run_stage1_smoke.py"),
+                "--train-split",
+                str(train_split_path),
+                "--val-split",
+                str(val_split_path),
+                "--archive-path",
+                str(archive_path),
+                "--image-size",
+                "64",
+                "--batch-size",
+                "2",
+                "--epochs",
+                "1",
+                "--output-dir",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertIn("Stage 1 smoke test finished successfully", completed.stdout)
+
+        report_path = output_dir / "stage1_smoke_report.md"
+        train_metrics_path = output_dir / "train" / "metrics_summary.json"
+        eval_metrics_path = output_dir / "eval" / "breast_level_metrics.json"
+        image_predictions_path = output_dir / "eval" / "image_level_predictions.csv"
+        breast_predictions_path = output_dir / "eval" / "breast_level_predictions.csv"
+
+        self.assertTrue(report_path.exists())
+        self.assertTrue(train_metrics_path.exists())
+        self.assertTrue(eval_metrics_path.exists())
+        self.assertTrue(image_predictions_path.exists())
+        self.assertTrue(breast_predictions_path.exists())
+        self.assertTrue((output_dir / "train_stdout.log").exists())
+        self.assertTrue((output_dir / "eval_stdout.log").exists())
+
+        report_text = report_path.read_text(encoding="utf-8")
+        self.assertIn("# Stage 1 Smoke Report", report_text)
+        self.assertIn("## Pipeline Coverage", report_text)
+        self.assertIn("Current loop status:", report_text)
+        self.assertIn("Main limitation:", report_text)
+        self.assertIn(str(train_metrics_path), report_text)
+        self.assertIn(str(eval_metrics_path), report_text)
+
+        train_metrics = json.loads(train_metrics_path.read_text(encoding="utf-8"))
+        eval_metrics = json.loads(eval_metrics_path.read_text(encoding="utf-8"))
+        self.assertEqual(train_metrics["best_epoch"], 1)
+        self.assertIn("breast_auroc", eval_metrics)
+        self.assertIn("auroc_available", eval_metrics)
+
+    def write_split_summary(self, split_dir: Path) -> None:
+        summary = {
+            "fold_assignment": {
+                "val_fold": 0,
+                "train_folds": [1, 2, 3, 4],
+            },
+            "paired": {
+                "val": {
+                    "label_counts": {"0": 1, "1": 1},
+                }
+            },
+            "single": {
+                "val": {
+                    "label_counts": {"0": 2, "1": 2},
+                }
+            },
+        }
+        (split_dir / "primary_split_summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def build_rows(self, specs: list[tuple[str, int]]) -> list[dict[str, str]]:
+        rows: list[dict[str, str]] = []
+        for breast_id, label in specs:
+            laterality = breast_id.split("_")[-1]
+            pathology = "M" if label == 1 else "N"
+            birads = "4C" if label == 1 else "1"
+            for view in ("CC", "MLO"):
+                rows.append(
+                    {
+                        "image_id": f"{breast_id}_{view}",
+                        "breast_id": breast_id,
+                        "view": view,
+                        "pathology": pathology,
+                        "is_malignant": str(label),
+                        "image_path": f"train_img/{breast_id}/{breast_id}_{view}.jpg",
+                        "laterality": laterality,
+                        "device": "HLG",
+                        "lesion_type": "",
+                        "birads": birads,
+                        "difficult": "N",
+                        "annotations": "[]",
+                    }
+                )
+        return rows
+
+    def write_archive(self, archive_path: Path, rows: list[dict[str, str]]) -> None:
+        with ZipFile(archive_path, "w") as archive:
+            for row in rows:
+                label = int(row["is_malignant"])
+                bright_left = row["view"] == "CC"
+                pixels = self.make_rgb_image(width=32, height=40, label=label, bright_left=bright_left)
+                archive.writestr(row["image_path"], self.encode_image(pixels))
+
+    def write_csv(self, path: Path, rows: list[dict[str, str]]) -> None:
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=SINGLE_IMAGE_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def make_rgb_image(self, width: int, height: int, label: int, bright_left: bool) -> np.ndarray:
+        pixels = np.zeros((height, width), dtype=np.uint8)
+        pixels[2:-2, 2:-2] = 30 if label == 0 else 150
+        if bright_left:
+            pixels[6:-6, 3 : width // 2] = 220 if label == 1 else 90
+        else:
+            pixels[6:-6, width // 2 : -3] = 220 if label == 1 else 90
+        return np.repeat(pixels[:, :, None], 3, axis=2)
+
+    def encode_image(self, rgb_pixels: np.ndarray) -> bytes:
+        image = Image.fromarray(rgb_pixels)
+        buffer = BytesIO()
+        image.save(buffer, format="JPEG")
+        return buffer.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
what:
- add a minimal Stage 1 smoke script that reuses the existing split, training, and evaluation pipeline to run one end-to-end train/val/eval pass
- save smoke logs, training outputs, evaluation artifacts, and a markdown sanity report with key paths and observations
- add a focused integration test to verify the smoke script generates the report and required artifacts

why:
- satisfy Issue 1.6 by turning the current minimal pipeline into one reviewable end-to-end smoke run
- provide a concrete sanity record that shows the loop is runnable while also surfacing current risks such as weak or collapsed predictions