### PR TITLE
docs(stage1): sync stage1 usage notes and handoff documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,96 +4,131 @@
 
 This repository is a course project for breast cancer detection from mammography images.
 
-The repository is currently in Stage 0: bootstrap the project, make the dataset layout explicit, inspect the provided data, and define the initial task and evaluation protocol.
+The repository is currently in Stage 1: a minimal runnable pipeline is in place for the breast-level malignant probability task.
 
 Current status:
-- dataset archives, labels, and the submission template are present under `data/raw/primary/`
-- repository directories exist
-- task and data conventions are documented
-- no training pipeline or baseline model is implemented yet
+- Stage 1 data indexing, grouped split, training, evaluation, and smoke-test scripts are implemented
+- the current runnable baseline trains on single-image inputs and reports breast-level metrics through aggregation
+- breast-level evaluation artifacts and one end-to-end smoke report are available under `outputs/`
+- the current outputs only show that the pipeline runs end to end; they do not yet indicate a strong baseline
 
 ## Current Stage and Scope
 
-In scope for the current stage:
-- repository structure and developer-facing documentation
-- data directory conventions
-- lightweight dataset inspection utilities
-- task definition and evaluation protocol
+In scope for the current repository state:
+- reproducible data indexing and paired breast-level sample definitions
+- lightweight preprocessing and dataset loading
+- `breast_id`-grouped split artifacts and fold assignment
+- a minimal single-image baseline train/val loop
+- minimal breast-level aggregation and evaluation artifacts
+- one end-to-end smoke test and sanity report
 
 Out of scope for the current stage:
-- large-scale training
-- complex preprocessing pipelines
-- aggressive optimization
-- external dataset integration beyond storage conventions
+- paired dual-branch training as the mainline baseline
+- cross-validation training orchestration
+- hyperparameter search and benchmark tuning
+- heavy evaluator or experiment-management frameworks
+- Milestone 2 model upgrades
 
 ## Repository Structure
 
-- `configs/`: placeholder for future configuration files
-- `data/`: raw, interim, and processed data layout plus data conventions
-- `docs/`: planning material and project documentation
-- `outputs/`: generated artifacts such as figures, logs, and checkpoints
-- `scripts/`: lightweight runnable utilities
-- `src/`: placeholders for future `models`, `train`, and `eval` code
-- `requirements.txt`: placeholder for later stages; Stage 0 utilities use the Python standard library only
+- `src/data/`: dataset index building, transforms, datasets, and grouped split utilities
+- `src/models/`: the minimal single-image baseline model
+- `src/train/`: train/val loop, checkpoint selection, and metric summary logic
+- `src/eval/`: breast-level aggregation, AUROC calculation, and evaluation artifact writing
+- `scripts/`: runnable Stage 1 entry points
+- `data/processed/metadata/`: generated dataset index artifacts
+- `data/processed/splits/`: generated split and fold assignment artifacts
+- `outputs/m1_baseline/`: baseline training outputs and evaluation artifacts
+- `outputs/m1_smoke/`: end-to-end smoke logs, outputs, and sanity report
 
 ## Data Organization
 
-The primary course dataset currently lives under `data/raw/primary/`.
+The primary course dataset is expected under `data/raw/primary/`.
 
-Expected files:
+Required raw inputs:
 - `train.csv`
 - `train_img.zip`
 - `test_img.zip`
 - `name_sid_submission.csv`
-- the course dataset note DOCX
 
-Observed dataset facts from the current intake:
-- `train.csv` contains 1,300 labeled image rows for 650 `breast_id` studies
-- each `breast_id` has exactly two views: one `CC` image and one `MLO` image
-- the submission template expects one malignant probability per `breast_id`
+Generated Stage 1 artifacts live under:
+- `data/processed/metadata/`
+- `data/processed/splits/`
+- `outputs/m1_baseline/`
+- `outputs/m1_smoke/`
 
-See `data/README.md` for directory rules and the current intake summary.
+See `data/README.md` for the data layout rules and `docs/handoff/stage1_handoff.md` for the Stage 1 artifact map.
 
 ## Environment and Setup
 
 Recommended:
 - Python 3.10 or newer
 
-Stage 0 setup:
-1. Clone the repository.
-2. Keep the provided raw dataset files under `data/raw/primary/`.
-3. Do not modify raw files in place.
-4. If you extract image archives locally, place extracted files under `data/interim/primary/`.
+Current Stage 1 scripts require the runtime environment to provide:
+- `numpy`
+- `Pillow`
+- `torch`
+- `scikit-learn`
 
-No third-party dependencies are required for the current inspection utility.
+Notes:
+- keep the provided raw dataset files under `data/raw/primary/`
+- do not edit raw files in place
+- `requirements.txt` is still not curated for Stage 1, so dependency locking remains a follow-up item
 
 ## Minimal Usage
 
-Review the current Stage 0 materials:
+If the processed artifacts already exist, you can start from training or smoke. Otherwise, the minimal Stage 1 flow is:
 
-1. Read the stage planning docs in `docs/plan/`, the issue breakdown in `docs/gitflow/issue/`, and the Git workflow in `docs/gitflow/workflow.md`.
-2. Inspect the dataset with:
+1. Build dataset indexes:
 
 ```bash
-python scripts/inspect_dataset.py
+python scripts/build_dataset_index.py
 ```
 
-3. Read the task and evaluation protocol in `docs/task_definition.md`.
-4. Read the data layout conventions in `data/README.md`.
+2. Build grouped splits and fold assignment:
 
-There is no training entry point yet. Stage 1 is expected to add the first minimal runnable baseline pipeline.
+```bash
+python scripts/build_splits.py
+```
+
+3. Train the minimal baseline:
+
+```bash
+python scripts/train_baseline.py --epochs 1 --batch-size 8 --image-size 512
+```
+
+4. Run breast-level evaluation from the validation split:
+
+```bash
+python scripts/run_eval.py --checkpoint outputs/m1_baseline/best_model.pt --image-size 512 --output-dir outputs/m1_baseline/eval
+```
+
+5. Run the end-to-end smoke test and generate a sanity report:
+
+```bash
+python scripts/run_stage1_smoke.py
+```
+
+For a fuller Stage 1 runbook, artifact map, and current limitations, read `docs/handoff/stage1_handoff.md`.
 
 ## Current Progress
 
-- repository bootstrap structure is in place
-- raw primary dataset files are stored in the repository data layout
-- breast-level prediction target is documented
-- evaluation is defined around AUROC, matching the course submission requirement
-- a reproducible inspection script is available for verifying the current dataset assumptions
+- dataset indexes exist for both single-image and paired breast-level views
+- minimal preprocessing and dataset loading are implemented
+- grouped train/val splits and 5-fold assignment artifacts are generated by `breast_id`
+- a minimal single-image training loop and checkpoint selection flow are implemented
+- breast-level aggregation and AUROC evaluation artifacts are implemented
+- an end-to-end smoke script records one sanity run and its findings
+
+## Current Limitations
+
+- the training path is still a single-image baseline, not the intended paired breast-level baseline
+- the current smoke run shows weak, tightly clustered predictions and should not be treated as a meaningful performance result
+- fold assignment artifacts exist, but there is no full cross-validation training runner yet
+- dependency packaging is still lightweight and not yet cleaned up for handoff outside the current environment
 
 ## Next Steps
 
-- create breast-level train/validation splits keyed by `breast_id`
-- define the first minimal baseline data loading path
-- implement a simple baseline that consumes paired `CC` and `MLO` views
-- add validation reporting around the documented task definition
+- use the Stage 1 artifacts as the starting point for Milestone 2 baseline work
+- prioritize a stronger breast-level modeling path over further polishing the current single-image fallback
+- diagnose and reduce prediction-collapse risk before treating validation numbers as informative

--- a/data/README.md
+++ b/data/README.md
@@ -2,17 +2,17 @@
 
 ## Purpose
 
-This file defines the Stage 0 data layout and records the current intake status of the primary course dataset.
+This file defines the repository data layout and records the current intake status of the primary course dataset.
 
 In scope:
 - directory conventions
 - storage rules for raw, interim, and processed data
-- the observed dataset summary needed to unblock a minimal baseline
+- the current Stage 1 generated metadata and split artifacts
 
 Out of scope:
-- final preprocessing design
+- detailed preprocessing design
 - external dataset integration details
-- heavy feature engineering
+- model-training logic
 
 ## Directory Layout
 
@@ -20,8 +20,8 @@ Out of scope:
 - `raw/external/`: optional external datasets downloaded for later comparison or augmentation
 - `interim/primary/`: extracted or lightly reorganized versions of the primary dataset used for inspection or loading
 - `interim/external/`: extracted or lightly reorganized external datasets
-- `processed/metadata/`: derived small metadata tables such as breast-level labels or manifests
-- `processed/splits/`: train/validation split files keyed by `breast_id`
+- `processed/metadata/`: derived small metadata tables such as dataset indexes and validation reports
+- `processed/splits/`: train/validation split files and fold assignment artifacts keyed by `breast_id`
 - `processed/cache/`: optional generated caches; create only when needed
 
 ## Current Primary Dataset Intake
@@ -41,7 +41,7 @@ Observed dataset structure:
 - `pathology` is consistent across the two views of each breast, so a breast-level target can be derived safely
 - `annotations` are empty for normal cases and contain polygon ROI strings for abnormal cases
 
-Current Stage 0 summary:
+Current dataset summary:
 - breast-level pathology counts: `N=412`, `B=81`, `M=157`
 - image-level pathology counts: `N=824`, `B=162`, `M=314`
 - annotated image rows: `476 / 1300`
@@ -53,12 +53,30 @@ These counts can be regenerated with:
 python scripts/inspect_dataset.py
 ```
 
+## Current Stage 1 Generated Artifacts
+
+Current index artifacts under `processed/metadata/`:
+- `primary_single_image_index.csv`
+- `primary_paired_breast_index.csv`
+- `primary_index_report.json`
+
+Current split artifacts under `processed/splits/`:
+- `primary_single_image_split_train.csv`
+- `primary_single_image_split_val.csv`
+- `primary_paired_breast_split_train.csv`
+- `primary_paired_breast_split_val.csv`
+- `primary_fold_assignment.csv`
+- `primary_fold_summary.json`
+- `primary_split_summary.json`
+
+These files are small, reproducible project artifacts that describe how Stage 1 reads and splits the dataset.
+
 ## Usage Rules
 
 - do not edit files inside `raw/primary/` in place
 - keep raw filenames and relative paths stable unless there is a documented reason to change them
 - extract archives into `interim/primary/` rather than next to the raw zip files
-- store derived breast-level manifests under `processed/metadata/`
-- store train/validation split definitions under `processed/splits/`
+- store derived dataset indexes under `processed/metadata/`
+- store train/validation split definitions and fold assignment under `processed/splits/`
 - keep all file references repository-relative
 - document any new external dataset before using it in code

--- a/docs/ai/feedback/stage1/feedback_stage1-7.md
+++ b/docs/ai/feedback/stage1/feedback_stage1-7.md
@@ -1,0 +1,109 @@
+1. 修改了哪些文档/文件
+
+修改了 [README.md](d:/MyProject/Breast-Cancer-Detection-Model/README.md)、[data/README.md](d:/MyProject/Breast-Cancer-Detection-Model/data/README.md)，新增了 [docs/handoff/stage1_handoff.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/handoff/stage1_handoff.md)。
+
+2. 每个文件的作用
+
+[README.md](d:/MyProject/Breast-Cancer-Detection-Model/README.md) 现在负责给出 Stage 1 的最小运行入口、当前范围和边界。  
+[data/README.md](d:/MyProject/Breast-Cancer-Detection-Model/data/README.md) 现在补齐了 Stage 1 已生成的 metadata / split / fold artifact。  
+[stage1_handoff.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/handoff/stage1_handoff.md) 是给未来自己/新成员的工程交接文档，重点回答“怎么跑、产物在哪、当前到哪一步、主要风险是什么”。
+
+3. README 更新了什么
+
+README 从原来的 Stage 0 状态改成了 Stage 1 状态，主要补了这些内容：
+
+- 当前已经有最小可运行 pipeline，而不是“尚未实现训练入口”
+- 最小运行命令：`build_dataset_index`、`build_splits`、`train_baseline`、`run_eval`、`run_stage1_smoke`
+- 当前仓库结构里和 M1 直接相关的目录与脚本
+- 当前边界：训练仍是 single-image fallback，不是正式 paired baseline
+- 当前限制：smoke 结果只能说明闭环成立，不说明 baseline 已经有效
+
+4. Stage 1 handoff / summary 文档包含哪些部分
+
+[stage1_handoff.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/handoff/stage1_handoff.md) 包含：
+
+- Stage 1 已完成内容
+- 当前任务定义与边界
+- 关键代码目录、脚本和 artifact 路径
+- 最小 runbook
+- 每个入口脚本会产出什么
+- 当前 smoke 的已知发现
+- 已知问题与进入 M2 前的注意事项
+- 对未来工作的几个实用提醒
+
+5. 文档里如何说明最小运行入口
+
+README 和 handoff 都明确给了这几条命令：
+
+```bash
+python scripts/build_dataset_index.py
+python scripts/build_splits.py
+python scripts/train_baseline.py --epochs 1 --batch-size 8 --image-size 512
+python scripts/run_eval.py --checkpoint outputs/m1_baseline/best_model.pt --image-size 512 --output-dir outputs/m1_baseline/eval
+python scripts/run_stage1_smoke.py
+```
+
+同时 handoff 里还把关键输入和输出目录写清楚了：
+- [data/processed/metadata](d:/MyProject/Breast-Cancer-Detection-Model/data/processed/metadata)
+- [data/processed/splits](d:/MyProject/Breast-Cancer-Detection-Model/data/processed/splits)
+- [outputs/m1_baseline](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_baseline)
+- [outputs/m1_smoke](d:/MyProject/Breast-Cancer-Detection-Model/outputs/m1_smoke)
+
+6. 文档里如何说明 M1 已完成与未完成范围
+
+文档明确写了：
+
+已完成：
+- single-image / paired breast-level index
+- dataset / transforms
+- `breast_id`-grouped split 和 fold assignment
+- minimal single-image baseline train/val
+- minimal eval + breast-level aggregation
+- end-to-end smoke test
+
+未完成：
+- paired dual-branch breast-level training 主线
+- multi-fold training orchestration
+- M2 的正式 baseline 提升
+- benchmark / tuning / complex experiment management
+
+7. 文档里记录了哪些已知问题与后续注意事项
+
+文档明确记录了这些问题和注意事项：
+
+- 当前主训练路径仍是 single-image fallback，而最终任务是 breast-level multi-view
+- 当前 smoke 暴露出 prediction collapse 风险，预测分布过窄
+- 当前结果只能说明闭环成立，不能说明 baseline 已经有效
+- 进入 M2 前最值得优先处理的是更强的 breast-level 建模和塌缩问题诊断
+- `requirements.txt` 仍未整理，这是工程交接时的已知短板
+
+8. 给出一段文档示例
+
+来自 [stage1_handoff.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/handoff/stage1_handoff.md)：
+
+```md
+The frozen project task is still breast-level malignant probability prediction.
+
+Current Stage 1 training path:
+- train a single-image classifier on the grouped single-image split
+- aggregate validation predictions back to `breast_id` during evaluation
+
+Interpretation:
+- this is a runnable fallback path, not the intended final breast-level baseline
+- Stage 1 proves the pipeline is structurally correct enough to load data, train, validate, aggregate, and report breast-level metrics
+- Stage 1 does not prove that the current baseline is strong
+```
+
+9. 明确说明这次实现如何对应 issue_stage1.md 中 Issue 1.7 的 Goal / Scope / Deliverables / Acceptance Criteria
+
+这次实现是直接对齐 Issue 1.7 的：
+
+- Goal：把 Stage 1 的工程文档和运行说明同步到当前真实代码状态
+- Scope：更新了 README、补了 handoff 文档、补了关键目录/脚本说明、记录了已知问题和后续注意事项
+- Deliverables：已经有文档更新和 Stage 1 handoff 文档
+- Acceptance Criteria：现在新成员或未来自己可以根据文档快速找到 M1 产物、知道怎么跑最小 pipeline、知道 M1 做到了什么和没做到什么，而且文档内容已经从原先的 Stage 0 状态修正为和当前代码/产物一致
+
+路径差异说明：
+- 本次权威 issue 文档使用的是 [docs/gitflow/issue/issue_stage1.md](d:/MyProject/Breast-Cancer-Detection-Model/docs/gitflow/issue/issue_stage1.md)
+- 之前 README 停留在 Stage 0，这次已经按实际代码状态修正
+- 这次没有越界到 M2 方案设计，也没有改训练/评估逻辑，只做了文档同步和交接说明

--- a/docs/handoff/stage1_handoff.md
+++ b/docs/handoff/stage1_handoff.md
@@ -1,0 +1,177 @@
+# Stage 1 Handoff
+
+## Purpose
+
+This document is the Stage 1 engineering handoff for the minimal runnable pipeline.
+
+Use it to answer four questions quickly:
+- what Stage 1 already implements
+- how to run the minimal pipeline
+- where the generated artifacts live
+- what limitations and risks still block a stronger baseline
+
+## Stage 1 Status
+
+Stage 1 is complete as a minimal runnable pipeline.
+
+Implemented now:
+- dataset indexes for single-image and paired breast-level views
+- minimal preprocessing and dataset loading
+- `breast_id`-grouped train/val split plus 5-fold assignment artifacts
+- minimal single-image baseline training and validation
+- breast-level aggregation and AUROC evaluation artifacts
+- one end-to-end smoke test with a sanity report
+
+Not implemented yet:
+- paired dual-branch breast-level training as the main training path
+- multi-fold training orchestration
+- stronger baseline engineering for M2
+- benchmark-oriented tuning or experiment management
+
+## Task Definition and Current Boundary
+
+The frozen project task is still breast-level malignant probability prediction.
+
+Current Stage 1 training path:
+- train a single-image classifier on the grouped single-image split
+- aggregate validation predictions back to `breast_id` during evaluation
+
+Interpretation:
+- this is a runnable fallback path, not the intended final breast-level baseline
+- Stage 1 proves the pipeline is structurally correct enough to load data, train, validate, aggregate, and report breast-level metrics
+- Stage 1 does not prove that the current baseline is strong
+
+## Key Paths
+
+Core code:
+- `src/data/`: index building, datasets, transforms, split generation
+- `src/eval/`: aggregation, AUROC, evaluation artifact writing
+- `src/models/`: minimal CNN baseline
+- `src/train/`: train/val loop and checkpoint-selection logic
+
+Main runnable scripts:
+- `scripts/build_dataset_index.py`: build Stage 1 metadata indexes
+- `scripts/build_splits.py`: build grouped train/val splits and fold assignment
+- `scripts/check_dataset_loading.py`: dataset-loading smoke and preview helper
+- `scripts/train_baseline.py`: minimal single-image baseline training
+- `scripts/run_eval.py`: breast-level evaluation from a validation split and checkpoint
+- `scripts/run_stage1_smoke.py`: end-to-end Stage 1 smoke run and sanity report
+
+Generated metadata and split artifacts:
+- `data/processed/metadata/primary_single_image_index.csv`
+- `data/processed/metadata/primary_paired_breast_index.csv`
+- `data/processed/metadata/primary_index_report.json`
+- `data/processed/splits/primary_single_image_split_train.csv`
+- `data/processed/splits/primary_single_image_split_val.csv`
+- `data/processed/splits/primary_paired_breast_split_train.csv`
+- `data/processed/splits/primary_paired_breast_split_val.csv`
+- `data/processed/splits/primary_fold_assignment.csv`
+- `data/processed/splits/primary_fold_summary.json`
+- `data/processed/splits/primary_split_summary.json`
+
+Generated training and evaluation outputs:
+- `outputs/m1_baseline/config.json`
+- `outputs/m1_baseline/metrics_summary.json`
+- `outputs/m1_baseline/best_model.pt`
+- `outputs/m1_baseline/eval/image_level_predictions.csv`
+- `outputs/m1_baseline/eval/breast_level_predictions.csv`
+- `outputs/m1_baseline/eval/breast_level_metrics.json`
+
+Generated smoke outputs:
+- `outputs/m1_smoke/train/`
+- `outputs/m1_smoke/eval/`
+- `outputs/m1_smoke/train_stdout.log`
+- `outputs/m1_smoke/train_stderr.log`
+- `outputs/m1_smoke/eval_stdout.log`
+- `outputs/m1_smoke/eval_stderr.log`
+- `outputs/m1_smoke/stage1_smoke_report.md`
+
+## Minimal Runbook
+
+If Stage 1 processed artifacts do not exist yet:
+
+```bash
+python scripts/build_dataset_index.py
+python scripts/build_splits.py
+```
+
+Minimal baseline training:
+
+```bash
+python scripts/train_baseline.py --epochs 1 --batch-size 8 --image-size 512
+```
+
+Minimal evaluation from the validation split:
+
+```bash
+python scripts/run_eval.py --checkpoint outputs/m1_baseline/best_model.pt --image-size 512 --output-dir outputs/m1_baseline/eval
+```
+
+End-to-end smoke run:
+
+```bash
+python scripts/run_stage1_smoke.py
+```
+
+Optional dataset-loading check:
+
+```bash
+python scripts/check_dataset_loading.py --dataset paired --batch-size 2 --num-batches 1 --save-preview
+```
+
+## What To Expect From Each Entry Point
+
+`build_dataset_index.py`
+- reads `data/raw/primary/train.csv` and `train_img.zip`
+- writes dataset indexes and an index report to `data/processed/metadata/`
+
+`build_splits.py`
+- reads the Stage 1 indexes
+- writes grouped train/val splits, fold assignment, and split summaries to `data/processed/splits/`
+
+`train_baseline.py`
+- trains the minimal single-image CNN on the grouped single-image split
+- writes config, metric summary, and the best checkpoint to `outputs/m1_baseline/`
+
+`run_eval.py`
+- loads the validation split and checkpoint
+- writes image-level predictions, breast-level predictions, and breast-level metrics to `outputs/m1_baseline/eval/`
+
+`run_stage1_smoke.py`
+- reruns training and evaluation end to end under `outputs/m1_smoke/`
+- writes logs plus a markdown sanity report
+
+## Current Known Findings
+
+The current Stage 1 smoke run already highlights an important limitation.
+
+From `outputs/m1_smoke/stage1_smoke_report.md`:
+- the grouped validation breast labels match the evaluation artifact labels, so the pipeline looks structurally aligned
+- train and validation loss remain finite
+- breast-level AUROC is produced successfully: `0.4225`
+- predictions are tightly clustered, with breast-level prediction spread roughly `0.5655` to `0.5922` and `std=0.0049`
+
+Interpretation:
+- Stage 1 succeeds as a runnable sanity pipeline
+- Stage 1 does not yet succeed as a useful baseline
+- the current model shows near-constant output behavior and weak discrimination
+
+## Known Issues and M2 Attention Points
+
+Known issues now:
+- the main training path is still single-image, while the official task is breast-level and naturally multi-view
+- current smoke outputs show prediction-collapse risk and weak AUROC
+- `requirements.txt` is still not curated, so environment portability is weaker than the code path itself
+
+Priority attention before or during M2:
+- move from the single-image fallback path toward a stronger breast-level baseline
+- diagnose why predictions remain tightly clustered before trusting validation metrics
+- keep evaluation centered on breast-level metrics, even if image-level training is still used as a stepping stone
+- treat fold artifacts as the reproducibility anchor if multi-fold training is added later
+
+## Practical Notes For Future Work
+
+- Use the generated fold assignment to keep future experiments group-aware and reproducible.
+- Do not interpret the current Stage 1 numbers as benchmark-quality results.
+- If README and older planning notes differ from actual artifact names, trust the current scripts and paths listed in this document.
+- `data/README.md` is the quick reference for data layout; this handoff document is the quick reference for Stage 1 runtime and outputs.


### PR DESCRIPTION
what:
- update the README to reflect the actual Stage 1 pipeline, runnable entry points, and current repository scope
- add a Stage 1 handoff document that maps key scripts, artifacts, outputs, and the minimal runbook
- refresh the data guide so the generated metadata, split, and fold artifacts match the current code and file layout

why:
- make the Stage 1 state understandable and runnable for a new collaborator or for future work
- ensure the documentation matches the real codebase, artifact locations, and current limitations before moving into M2